### PR TITLE
Add .npmrc with legacy-peer-deps for React 19 compatibility

### DIFF
--- a/autoshop-pos/.npmrc
+++ b/autoshop-pos/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
@nozbe/with-observables@1.6.0 declares peerDep @types/react ^16||^17||^18 but the project uses @types/react@19. Setting legacy-peer-deps=true avoids the ERESOLVE error on npm install without affecting runtime behaviour.