### PR TITLE
AMSPOS-3: Create WatermelonDB Model Classes

### DIFF
--- a/autoshop-pos/src/models/AddOnModel.ts
+++ b/autoshop-pos/src/models/AddOnModel.ts
@@ -1,0 +1,12 @@
+import { Model } from '@nozbe/watermelondb';
+import { text, field, date } from '@nozbe/watermelondb/decorators';
+
+export class AddOnModel extends Model {
+  static table = 'add_ons';
+
+  @text('name') name!: string;
+  @field('amount') amount!: number;
+  @field('is_active') isActive!: boolean;
+  @date('created_at') createdAt!: Date;
+  @text('created_by') createdBy!: string;
+}

--- a/autoshop-pos/src/models/AuditLogModel.ts
+++ b/autoshop-pos/src/models/AuditLogModel.ts
@@ -1,0 +1,16 @@
+import { Model } from '@nozbe/watermelondb';
+import { text, date } from '@nozbe/watermelondb/decorators';
+
+export class AuditLogModel extends Model {
+  static table = 'audit_logs';
+
+  @date('timestamp') timestamp!: Date;
+  @text('user_id') userId!: string;
+  @text('user_name') userName!: string;
+  @text('action_type') actionType!: string;
+  @text('entity_type') entityType!: string;
+  @text('entity_id') entityId!: string;
+  @text('before') before!: string;
+  @text('after') after!: string;
+  @text('note') note!: string;
+}

--- a/autoshop-pos/src/models/CategoryModel.ts
+++ b/autoshop-pos/src/models/CategoryModel.ts
@@ -1,0 +1,10 @@
+import { Model } from '@nozbe/watermelondb';
+import { text, date } from '@nozbe/watermelondb/decorators';
+
+export class CategoryModel extends Model {
+  static table = 'categories';
+
+  @text('name') name!: string;
+  @date('created_at') createdAt!: Date;
+  @text('created_by') createdBy!: string;
+}

--- a/autoshop-pos/src/models/CustomerModel.ts
+++ b/autoshop-pos/src/models/CustomerModel.ts
@@ -1,0 +1,14 @@
+import { Model } from '@nozbe/watermelondb';
+import { text, field, date } from '@nozbe/watermelondb/decorators';
+
+export class CustomerModel extends Model {
+  static table = 'customers';
+
+  @text('type') type!: 'NAMED' | 'WALKIN';
+  @text('name') name!: string;
+  @text('phone') phone!: string;
+  @text('email') email!: string;
+  @field('is_active') isActive!: boolean;
+  @date('created_at') createdAt!: Date;
+  @text('created_by') createdBy!: string;
+}

--- a/autoshop-pos/src/models/LineItemAddOnModel.ts
+++ b/autoshop-pos/src/models/LineItemAddOnModel.ts
@@ -1,0 +1,15 @@
+import { Model } from '@nozbe/watermelondb';
+import { text, field } from '@nozbe/watermelondb/decorators';
+
+export class LineItemAddOnModel extends Model {
+  static table = 'line_item_add_ons';
+  static associations = {
+    line_items: { type: 'belongs_to', key: 'line_item_id' },
+  } as const;
+
+  @text('line_item_id') lineItemId!: string;
+  @text('add_on_id') addOnId!: string;
+  @text('name') name!: string;
+  @field('amount') amount!: number;
+  @field('is_on_the_fly') isOnTheFly!: boolean;
+}

--- a/autoshop-pos/src/models/LineItemModel.ts
+++ b/autoshop-pos/src/models/LineItemModel.ts
@@ -1,0 +1,26 @@
+import { Model } from '@nozbe/watermelondb';
+import { text, field, children } from '@nozbe/watermelondb/decorators';
+
+export class LineItemModel extends Model {
+  static table = 'line_items';
+  static associations = {
+    transactions: { type: 'belongs_to', key: 'transaction_id' },
+    line_item_add_ons: { type: 'has_many', foreignKey: 'line_item_id' },
+  } as const;
+
+  @text('transaction_id') transactionId!: string;
+  @text('type') type!: 'PRODUCT' | 'SERVICE';
+  @text('ref_id') refId!: string;
+  @text('name') name!: string;
+  @field('unit_price') unitPrice!: number;
+  @field('quantity') quantity!: number;
+  @text('vat_type') vatType!: string;
+  @text('discount_type') discountType!: string;
+  @field('discount_value') discountValue!: number;
+  @field('subtotal') subtotal!: number;
+  @field('vat_amount') vatAmount!: number;
+  @field('discount_amount') discountAmount!: number;
+  @field('total') total!: number;
+
+  @children('line_item_add_ons') addOns!: any;
+}

--- a/autoshop-pos/src/models/PaymentModel.ts
+++ b/autoshop-pos/src/models/PaymentModel.ts
@@ -1,0 +1,15 @@
+import { Model } from '@nozbe/watermelondb';
+import { text, field } from '@nozbe/watermelondb/decorators';
+
+export class PaymentModel extends Model {
+  static table = 'payments';
+  static associations = {
+    transactions: { type: 'belongs_to', key: 'transaction_id' },
+  } as const;
+
+  @text('transaction_id') transactionId!: string;
+  @text('method') method!: 'CASH' | 'GCASH' | 'MAYA';
+  @field('amount') amount!: number;
+  @text('reference_number') referenceNumber!: string;
+  @text('receipt_photo_uri') receiptPhotoUri!: string;
+}

--- a/autoshop-pos/src/models/ProductModel.ts
+++ b/autoshop-pos/src/models/ProductModel.ts
@@ -1,0 +1,22 @@
+import { Model } from '@nozbe/watermelondb';
+import { text, field, date } from '@nozbe/watermelondb/decorators';
+
+export class ProductModel extends Model {
+  static table = 'products';
+
+  @text('name') name!: string;
+  @text('barcode') barcode!: string;
+  @field('selling_price') sellingPrice!: number;
+  @field('cost_price') costPrice!: number;
+  @text('unit_of_measure') unitOfMeasure!: string;
+  @field('stock_available') stockAvailable!: number;
+  @field('stock_reserved') stockReserved!: number;
+  @field('low_stock_threshold') lowStockThreshold!: number;
+  @text('category_id') categoryId!: string;
+  @text('supplier_id') supplierId!: string;
+  @field('is_active') isActive!: boolean;
+  @date('created_at') createdAt!: Date;
+  @text('created_by') createdBy!: string;
+  @date('updated_at') updatedAt!: Date;
+  @text('updated_by') updatedBy!: string;
+}

--- a/autoshop-pos/src/models/ServiceModel.ts
+++ b/autoshop-pos/src/models/ServiceModel.ts
@@ -1,0 +1,14 @@
+import { Model } from '@nozbe/watermelondb';
+import { text, field, date } from '@nozbe/watermelondb/decorators';
+
+export class ServiceModel extends Model {
+  static table = 'services';
+
+  @text('name') name!: string;
+  @field('base_price') basePrice!: number;
+  @field('is_active') isActive!: boolean;
+  @date('created_at') createdAt!: Date;
+  @text('created_by') createdBy!: string;
+  @date('updated_at') updatedAt!: Date;
+  @text('updated_by') updatedBy!: string;
+}

--- a/autoshop-pos/src/models/SupplierModel.ts
+++ b/autoshop-pos/src/models/SupplierModel.ts
@@ -1,0 +1,11 @@
+import { Model } from '@nozbe/watermelondb';
+import { text, date } from '@nozbe/watermelondb/decorators';
+
+export class SupplierModel extends Model {
+  static table = 'suppliers';
+
+  @text('name') name!: string;
+  @text('contact_info') contactInfo!: string;
+  @date('created_at') createdAt!: Date;
+  @text('created_by') createdBy!: string;
+}

--- a/autoshop-pos/src/models/TransactionModel.ts
+++ b/autoshop-pos/src/models/TransactionModel.ts
@@ -1,0 +1,34 @@
+import { Model } from '@nozbe/watermelondb';
+import { text, field, date, children } from '@nozbe/watermelondb/decorators';
+
+export class TransactionModel extends Model {
+  static table = 'transactions';
+  static associations = {
+    line_items: { type: 'has_many', foreignKey: 'transaction_id' },
+    payments: { type: 'has_many', foreignKey: 'transaction_id' },
+  } as const;
+
+  @text('status') status!: string;
+  @text('customer_id') customerId!: string;
+  @text('vehicle_id') vehicleId!: string;
+  @text('cashier_id') cashierId!: string;
+  @field('subtotal') subtotal!: number;
+  @field('total_vat') totalVat!: number;
+  @field('total_amount') totalAmount!: number;
+  @field('change_due') changeDue!: number;
+  @field('has_return') hasReturn!: boolean;
+  @text('original_transaction_id') originalTransactionId!: string;
+  @text('void_reason') voidReason!: string;
+  @text('voided_by') voidedBy!: string;
+  @field('voided_at') voidedAt!: number;
+  @text('return_reason') returnReason!: string;
+  @text('returned_by') returnedBy!: string;
+  @field('returned_at') returnedAt!: number;
+  @date('created_at') createdAt!: Date;
+  @text('created_by') createdBy!: string;
+  @field('finalized_at') finalizedAt!: number;
+  @text('finalized_by') finalizedBy!: string;
+
+  @children('line_items') lineItems!: any;
+  @children('payments') payments!: any;
+}

--- a/autoshop-pos/src/models/UserModel.ts
+++ b/autoshop-pos/src/models/UserModel.ts
@@ -1,0 +1,23 @@
+import { Model } from '@nozbe/watermelondb';
+import { text, field, date, json } from '@nozbe/watermelondb/decorators';
+import { Permission } from '../types';
+
+const sanitizePermissions = (raw: unknown): Permission[] => {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((p): p is Permission => typeof p === 'string');
+};
+
+export class UserModel extends Model {
+  static table = 'users';
+
+  @text('display_name') displayName!: string;
+  @text('pin_hash') pinHash!: string;
+  @text('pin_salt') pinSalt!: string;
+  @json('permissions', sanitizePermissions) permissions!: Permission[];
+  @field('is_main_admin') isMainAdmin!: boolean;
+  @field('is_active') isActive!: boolean;
+  @date('created_at') createdAt!: Date;
+  @text('created_by') createdBy!: string;
+  @date('updated_at') updatedAt!: Date;
+  @text('updated_by') updatedBy!: string;
+}

--- a/autoshop-pos/src/models/VehicleModel.ts
+++ b/autoshop-pos/src/models/VehicleModel.ts
@@ -1,0 +1,14 @@
+import { Model } from '@nozbe/watermelondb';
+import { text, date } from '@nozbe/watermelondb/decorators';
+
+export class VehicleModel extends Model {
+  static table = 'vehicles';
+
+  @text('customer_id') customerId!: string;
+  @text('make') make!: string;
+  @text('model') model!: string;
+  @text('color') color!: string;
+  @text('plate_number') plateNumber!: string;
+  @date('created_at') createdAt!: Date;
+  @text('created_by') createdBy!: string;
+}

--- a/autoshop-pos/src/models/index.ts
+++ b/autoshop-pos/src/models/index.ts
@@ -1,0 +1,13 @@
+export { UserModel } from './UserModel';
+export { CategoryModel } from './CategoryModel';
+export { SupplierModel } from './SupplierModel';
+export { AddOnModel } from './AddOnModel';
+export { ProductModel } from './ProductModel';
+export { ServiceModel } from './ServiceModel';
+export { CustomerModel } from './CustomerModel';
+export { VehicleModel } from './VehicleModel';
+export { TransactionModel } from './TransactionModel';
+export { LineItemModel } from './LineItemModel';
+export { LineItemAddOnModel } from './LineItemAddOnModel';
+export { PaymentModel } from './PaymentModel';
+export { AuditLogModel } from './AuditLogModel';

--- a/autoshop-pos/src/services/database.ts
+++ b/autoshop-pos/src/services/database.ts
@@ -1,10 +1,11 @@
 import { Database } from '@nozbe/watermelondb';
 import SQLiteAdapter from '@nozbe/watermelondb/adapters/sqlite';
 import { schema } from './schema';
-
-// Model classes will be imported after AMSPOS-3
-// import { UserModel } from '../models/UserModel';
-// ... etc.
+import {
+  UserModel, CategoryModel, SupplierModel, AddOnModel, ProductModel,
+  ServiceModel, CustomerModel, VehicleModel, TransactionModel,
+  LineItemModel, LineItemAddOnModel, PaymentModel, AuditLogModel,
+} from '../models';
 
 const adapter = new SQLiteAdapter({
   schema,
@@ -18,6 +19,8 @@ const adapter = new SQLiteAdapter({
 export const database = new Database({
   adapter,
   modelClasses: [
-    // Register model classes here after AMSPOS-3
+    UserModel, CategoryModel, SupplierModel, AddOnModel, ProductModel,
+    ServiceModel, CustomerModel, VehicleModel, TransactionModel,
+    LineItemModel, LineItemAddOnModel, PaymentModel, AuditLogModel,
   ],
 });

--- a/autoshop-pos/src/types/index.ts
+++ b/autoshop-pos/src/types/index.ts
@@ -1,0 +1,10 @@
+export type Permission =
+  | 'manage_users'
+  | 'manage_products'
+  | 'manage_services'
+  | 'manage_customers'
+  | 'manage_transactions'
+  | 'void_transaction'
+  | 'process_return'
+  | 'view_reports'
+  | 'manage_settings';

--- a/autoshop-pos/tsconfig.json
+++ b/autoshop-pos/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "experimentalDecorators": true
   }
 }


### PR DESCRIPTION
## Summary

- Creates 13 WatermelonDB model classes in `src/models/` (one per table)
- Adds `Permission` type in `src/types/index.ts`
- Registers all models in `database.ts` `modelClasses` array
- Enables `experimentalDecorators` in `tsconfig.json`

## Changes

- `src/models/UserModel.ts` — uses `@json` with typed `Permission[]` sanitizer
- `src/models/TransactionModel.ts` — `@children` for `line_items` and `payments`
- `src/models/LineItemModel.ts` — `@children` for `line_item_add_ons`
- All other models follow decorator pattern (`@text`, `@field`, `@date`)
- `src/models/index.ts` — re-exports all models

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [ ] App boots without WatermelonDB setup errors

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)