### PR TITLE
AMSPOS-28: Create Common UI Atoms — AppButton, AppInput, AppBadge

### DIFF
--- a/autoshop-pos/src/components/common/AppBadge.tsx
+++ b/autoshop-pos/src/components/common/AppBadge.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Colors, Spacing, Typography, BorderRadius } from '@constants/theme';
+
+type BadgeVariant = 'success' | 'warning' | 'danger' | 'neutral' | 'primary';
+
+interface AppBadgeProps {
+  label: string;
+  variant?: BadgeVariant;
+}
+
+export const AppBadge: React.FC<AppBadgeProps> = ({ label, variant = 'neutral' }) => (
+  <View style={[styles.badge, styles[variant]]}>
+    <Text style={[styles.label, styles[`${variant}Label`]]}>{label}</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  badge: {
+    paddingVertical: 2,
+    paddingHorizontal: Spacing.sm,
+    borderRadius: BorderRadius.full,
+    alignSelf: 'flex-start',
+  },
+  label: { fontSize: Typography.xs, fontWeight: Typography.semiBold },
+
+  success: { backgroundColor: Colors.successLight },
+  successLabel: { color: Colors.success },
+  warning: { backgroundColor: Colors.warningLight },
+  warningLabel: { color: Colors.warning },
+  danger: { backgroundColor: Colors.dangerLight },
+  dangerLabel: { color: Colors.danger },
+  neutral: { backgroundColor: Colors.gray100 },
+  neutralLabel: { color: Colors.gray700 },
+  primary: { backgroundColor: Colors.primaryLight },
+  primaryLabel: { color: Colors.primary },
+});

--- a/autoshop-pos/src/components/common/AppButton.tsx
+++ b/autoshop-pos/src/components/common/AppButton.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet, ActivityIndicator, ViewStyle } from 'react-native';
+import { Colors, Spacing, Typography, BorderRadius } from '@constants/theme';
+
+type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost';
+type ButtonSize = 'sm' | 'md' | 'lg';
+
+interface AppButtonProps {
+  label: string;
+  onPress: () => void;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  disabled?: boolean;
+  loading?: boolean;
+  style?: ViewStyle;
+  fullWidth?: boolean;
+}
+
+export const AppButton: React.FC<AppButtonProps> = ({
+  label,
+  onPress,
+  variant = 'primary',
+  size = 'md',
+  disabled = false,
+  loading = false,
+  style,
+  fullWidth = false,
+}) => {
+  const isDisabled = disabled || loading;
+
+  return (
+    <TouchableOpacity
+      style={[
+        styles.base,
+        styles[variant],
+        styles[size],
+        fullWidth && styles.fullWidth,
+        isDisabled && styles.disabled,
+        style,
+      ]}
+      onPress={onPress}
+      disabled={isDisabled}
+      activeOpacity={0.7}
+    >
+      {loading ? (
+        <ActivityIndicator
+          color={variant === 'primary' ? Colors.white : Colors.primary}
+          size="small"
+        />
+      ) : (
+        <Text style={[styles.label, styles[`${variant}Label`], styles[`${size}Label`]]}>
+          {label}
+        </Text>
+      )}
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  base: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: BorderRadius.md,
+  },
+  fullWidth: { width: '100%' },
+  disabled: { opacity: 0.5 },
+
+  // Variants
+  primary: { backgroundColor: Colors.primary },
+  secondary: { backgroundColor: Colors.primaryLight, borderWidth: 1, borderColor: Colors.primary },
+  danger: { backgroundColor: Colors.danger },
+  ghost: { backgroundColor: 'transparent' },
+
+  // Sizes
+  sm: { paddingVertical: Spacing.xs, paddingHorizontal: Spacing.sm },
+  md: { paddingVertical: Spacing.sm + 2, paddingHorizontal: Spacing.md },
+  lg: { paddingVertical: Spacing.md, paddingHorizontal: Spacing.xl },
+
+  // Labels
+  label: { fontWeight: Typography.semiBold },
+  primaryLabel: { color: Colors.white },
+  secondaryLabel: { color: Colors.primary },
+  dangerLabel: { color: Colors.white },
+  ghostLabel: { color: Colors.primary },
+
+  smLabel: { fontSize: Typography.sm },
+  mdLabel: { fontSize: Typography.base },
+  lgLabel: { fontSize: Typography.lg },
+});

--- a/autoshop-pos/src/components/common/AppInput.tsx
+++ b/autoshop-pos/src/components/common/AppInput.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import { View, TextInput, Text, StyleSheet, TextInputProps, ViewStyle } from 'react-native';
+import { Colors, Spacing, Typography, BorderRadius } from '@constants/theme';
+
+interface AppInputProps extends Omit<TextInputProps, 'style'> {
+  label?: string;
+  error?: string;
+  containerStyle?: ViewStyle;
+}
+
+export const AppInput: React.FC<AppInputProps> = ({
+  label,
+  error,
+  containerStyle,
+  ...textInputProps
+}) => {
+  const [isFocused, setIsFocused] = useState(false);
+
+  return (
+    <View style={[styles.container, containerStyle]}>
+      {label ? <Text style={styles.label}>{label}</Text> : null}
+      <TextInput
+        style={[
+          styles.input,
+          isFocused && styles.inputFocused,
+          error ? styles.inputError : null,
+        ]}
+        placeholderTextColor={Colors.gray300}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        {...textInputProps}
+      />
+      {error ? <Text style={styles.errorText}>{error}</Text> : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { gap: Spacing.xs },
+  label: {
+    fontSize: Typography.sm,
+    fontWeight: Typography.medium,
+    color: Colors.gray700,
+  },
+  input: {
+    height: 44,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.md,
+    fontSize: Typography.base,
+    color: Colors.black,
+    backgroundColor: Colors.surface,
+  },
+  inputFocused: { borderColor: Colors.primary },
+  inputError: { borderColor: Colors.danger },
+  errorText: {
+    fontSize: Typography.sm,
+    color: Colors.danger,
+  },
+});

--- a/autoshop-pos/src/components/common/index.ts
+++ b/autoshop-pos/src/components/common/index.ts
@@ -1,0 +1,3 @@
+export { AppButton } from './AppButton';
+export { AppInput } from './AppInput';
+export { AppBadge } from './AppBadge';


### PR DESCRIPTION
Closes #9

## Summary
- Added `AppButton` with 4 variants (`primary`, `secondary`, `danger`, `ghost`), 3 sizes, `loading` and `disabled` states, and optional `fullWidth`
- Added `AppInput` with optional label, focus border highlight, and error state
- Added `AppBadge` with 5 color variants (`success`, `warning`, `danger`, `neutral`, `primary`)
- Added barrel export at `src/components/common/index.ts`

All styles use `StyleSheet.create` and all color/spacing/typography values come from `@constants/theme`.

## Test plan
- [x] Verify `AppButton` renders all 4 variants visually
- [x] Verify `AppButton` shows `ActivityIndicator` and is non-interactive when `loading={true}`
- [x] Verify `AppInput` shows focus border on focus, error border + message when `error` prop set
- [x] Verify `AppBadge` renders all 5 color variants
- [x] Confirm no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)