### PR TITLE
AMSPOS-12: Implement sessionStore — Login, Logout, Lock, Unlock

### DIFF
--- a/autoshop-pos/src/stores/__tests__/sessionStore.test.ts
+++ b/autoshop-pos/src/stores/__tests__/sessionStore.test.ts
@@ -1,0 +1,211 @@
+import { useSessionStore } from '../sessionStore';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('../../services/authService', () => ({
+  authenticateByPin: jest.fn(),
+  getUserById: jest.fn(),
+}));
+
+const mockClearDraft = jest.fn();
+
+jest.mock('../transactionDraftStore', () => ({
+  useTransactionDraftStore: {
+    getState: jest.fn(() => ({ clearDraft: mockClearDraft })),
+  },
+}));
+
+import { authenticateByPin, getUserById } from '../../services/authService';
+
+const mockAuthenticateByPin = authenticateByPin as jest.Mock;
+const mockGetUserById = getUserById as jest.Mock;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeUser(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'user-1',
+    displayName: 'Alice',
+    pinHash: 'hash-abc',
+    pinSalt: 'salt-abc',
+    permissions: [],
+    isMainAdmin: false,
+    isActive: true,
+    createdAt: new Date('2024-01-01'),
+    createdBy: 'system',
+    updatedAt: new Date('2024-01-02'),
+    updatedBy: 'system',
+    ...overrides,
+  };
+}
+
+function resetStore() {
+  useSessionStore.setState({ user: null, status: 'NONE', lastActivityAt: 0 });
+}
+
+// ─── login ────────────────────────────────────────────────────────────────────
+
+describe('login', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetStore();
+  });
+
+  it('sets user and status ACTIVE when getUserById returns a user', async () => {
+    const user = makeUser();
+    mockGetUserById.mockResolvedValue(user);
+
+    await useSessionStore.getState().login('user-1');
+
+    const state = useSessionStore.getState();
+    expect(state.user).toEqual(user);
+    expect(state.status).toBe('ACTIVE');
+    expect(state.lastActivityAt).toBeGreaterThan(0);
+  });
+
+  it('throws when getUserById returns null', async () => {
+    mockGetUserById.mockResolvedValue(null);
+
+    await expect(useSessionStore.getState().login('nonexistent')).rejects.toThrow(
+      'User not found after authentication.'
+    );
+  });
+
+  it('calls getUserById with the provided userId', async () => {
+    mockGetUserById.mockResolvedValue(makeUser());
+
+    await useSessionStore.getState().login('user-42');
+
+    expect(mockGetUserById).toHaveBeenCalledWith('user-42');
+  });
+});
+
+// ─── logout ───────────────────────────────────────────────────────────────────
+
+describe('logout', () => {
+  beforeEach(() => resetStore());
+
+  it('clears user, resets status to NONE, and zeroes lastActivityAt', () => {
+    useSessionStore.setState({ user: makeUser() as never, status: 'ACTIVE', lastActivityAt: 9999 });
+
+    useSessionStore.getState().logout();
+
+    const state = useSessionStore.getState();
+    expect(state.user).toBeNull();
+    expect(state.status).toBe('NONE');
+    expect(state.lastActivityAt).toBe(0);
+  });
+});
+
+// ─── lock ─────────────────────────────────────────────────────────────────────
+
+describe('lock', () => {
+  beforeEach(() => resetStore());
+
+  it('sets status to LOCKED without clearing the user', () => {
+    const user = makeUser();
+    useSessionStore.setState({ user: user as never, status: 'ACTIVE', lastActivityAt: 1000 });
+
+    useSessionStore.getState().lock();
+
+    const state = useSessionStore.getState();
+    expect(state.status).toBe('LOCKED');
+    expect(state.user).toEqual(user);
+  });
+});
+
+// ─── unlock ───────────────────────────────────────────────────────────────────
+
+describe('unlock', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetStore();
+  });
+
+  it('returns false and does not change state when PIN is wrong', async () => {
+    mockAuthenticateByPin.mockResolvedValue(null);
+    useSessionStore.setState({ status: 'LOCKED' });
+
+    const result = await useSessionStore.getState().unlock('000000');
+
+    expect(result).toBe(false);
+    expect(useSessionStore.getState().status).toBe('LOCKED');
+  });
+
+  it('returns true and sets status ACTIVE when PIN is correct (same user)', async () => {
+    const user = makeUser();
+    useSessionStore.setState({ user: user as never, status: 'LOCKED' });
+    mockAuthenticateByPin.mockResolvedValue(user);
+
+    const result = await useSessionStore.getState().unlock('123456');
+
+    expect(result).toBe(true);
+    const state = useSessionStore.getState();
+    expect(state.status).toBe('ACTIVE');
+    expect(state.user).toEqual(user);
+    expect(state.lastActivityAt).toBeGreaterThan(0);
+  });
+
+  it('does NOT clear draft when same user unlocks', async () => {
+    const user = makeUser({ id: 'user-1' });
+    useSessionStore.setState({ user: user as never, status: 'LOCKED' });
+    mockAuthenticateByPin.mockResolvedValue(user);
+
+    await useSessionStore.getState().unlock('123456');
+
+    expect(mockClearDraft).not.toHaveBeenCalled();
+  });
+
+  it('clears the draft store when a different user unlocks', async () => {
+    const alice = makeUser({ id: 'user-1' });
+    const bob = makeUser({ id: 'user-2', displayName: 'Bob' });
+    useSessionStore.setState({ user: alice as never, status: 'LOCKED' });
+    mockAuthenticateByPin.mockResolvedValue(bob);
+
+    const result = await useSessionStore.getState().unlock('654321');
+
+    expect(result).toBe(true);
+    expect(mockClearDraft).toHaveBeenCalledTimes(1);
+    expect(useSessionStore.getState().user).toEqual(bob);
+  });
+});
+
+// ─── refreshActivity ──────────────────────────────────────────────────────────
+
+describe('refreshActivity', () => {
+  beforeEach(() => resetStore());
+
+  it('updates lastActivityAt to approximately now', () => {
+    const before = Date.now();
+    useSessionStore.getState().refreshActivity();
+    const after = Date.now();
+
+    const { lastActivityAt } = useSessionStore.getState();
+    expect(lastActivityAt).toBeGreaterThanOrEqual(before);
+    expect(lastActivityAt).toBeLessThanOrEqual(after);
+  });
+});
+
+// ─── authenticatePin ──────────────────────────────────────────────────────────
+
+describe('authenticatePin', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('delegates to authenticateByPin and returns the user', async () => {
+    const user = makeUser();
+    mockAuthenticateByPin.mockResolvedValue(user);
+
+    const result = await useSessionStore.getState().authenticatePin('123456');
+
+    expect(result).toEqual(user);
+    expect(mockAuthenticateByPin).toHaveBeenCalledWith('123456');
+  });
+
+  it('returns null when PIN does not match any user', async () => {
+    mockAuthenticateByPin.mockResolvedValue(null);
+
+    const result = await useSessionStore.getState().authenticatePin('000000');
+
+    expect(result).toBeNull();
+  });
+});

--- a/autoshop-pos/src/stores/sessionStore.ts
+++ b/autoshop-pos/src/stores/sessionStore.ts
@@ -1,7 +1,9 @@
 import { create } from 'zustand';
+import { authenticateByPin, getUserById } from '../services/authService';
+import type { User } from '../types';
 
 interface SessionStore {
-  user: null; // will be typed as User | null in AMSPOS-12
+  user: User | null;
   status: 'NONE' | 'ACTIVE' | 'LOCKED';
   lastActivityAt: number;
 
@@ -10,6 +12,7 @@ interface SessionStore {
   lock: () => void;
   unlock: (pin: string) => Promise<boolean>;
   refreshActivity: () => void;
+  authenticatePin: (pin: string) => Promise<User | null>;
 }
 
 export const useSessionStore = create<SessionStore>((set, get) => ({
@@ -17,9 +20,64 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
   status: 'NONE',
   lastActivityAt: 0,
 
-  login: async (_userId) => { /* implemented in AMSPOS-12 */ },
-  logout: () => set({ user: null, status: 'NONE' }),
-  lock: () => set({ status: 'LOCKED' }),
-  unlock: async (_pin) => false,
-  refreshActivity: () => set({ lastActivityAt: Date.now() }),
+  /**
+   * Called after PIN is verified. Loads the user record from DB and sets status ACTIVE.
+   */
+  login: async (userId: string) => {
+    const user = await getUserById(userId);
+    if (!user) throw new Error('User not found after authentication.');
+    set({ user, status: 'ACTIVE', lastActivityAt: Date.now() });
+  },
+
+  /**
+   * Logs the current user out. All subscriptions are cleaned up by AppListeners.
+   */
+  logout: () => {
+    set({ user: null, status: 'NONE', lastActivityAt: 0 });
+  },
+
+  /**
+   * Locks the session. Status becomes LOCKED but user ref is preserved
+   * (needed to show the locked user's name on PinLockScreen).
+   */
+  lock: () => {
+    set({ status: 'LOCKED' });
+  },
+
+  /**
+   * Verifies the PIN and unlocks. Returns true if correct.
+   * If a different user unlocks (different PIN owner), clears the draft store
+   * to prevent User B from inheriting User A's transaction context.
+   */
+  unlock: async (pin: string): Promise<boolean> => {
+    const matchedUser = await authenticateByPin(pin);
+    if (!matchedUser) return false;
+
+    const currentUserId = get().user?.id;
+
+    if (matchedUser.id !== currentUserId) {
+      // Different user unlocked — clear draft store
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { useTransactionDraftStore } = require('./transactionDraftStore') as typeof import('./transactionDraftStore');
+      useTransactionDraftStore.getState().clearDraft();
+    }
+
+    set({ user: matchedUser, status: 'ACTIVE', lastActivityAt: Date.now() });
+    return true;
+  },
+
+  /**
+   * Resets the inactivity timer. Called on every user interaction.
+   */
+  refreshActivity: () => {
+    set({ lastActivityAt: Date.now() });
+  },
+
+  /**
+   * Exposed for the initial login flow (not unlock).
+   * Used by PinLockScreen / InitSetupScreen via usePinAuth hook.
+   */
+  authenticatePin: async (pin: string): Promise<User | null> => {
+    return authenticateByPin(pin);
+  },
 }));


### PR DESCRIPTION
## Summary
- Replaces the `sessionStore.ts` skeleton with a full implementation wired to `authService` (`getUserById`, `authenticateByPin`)
- `unlock()` uses a lazy `require()` for `transactionDraftStore` to break the circular dependency, and clears the draft when a different user unlocks
- Adds `authenticatePin` action for the initial login flow

## Tests
- 12 tests covering all acceptance criteria: `login`, `logout`, `lock`, `unlock` (same user, different user, wrong PIN), `refreshActivity`, `authenticatePin`
- All pass, `npx tsc --noEmit` clean

## Test plan
- [x] `npx jest src/stores/__tests__/sessionStore.test.ts` — 12/12 pass
- [x] `npx tsc --noEmit` — no errors
- [x] Login flow sets `status: ACTIVE` and populates `user`
- [x] Logout resets all fields
- [x] Lock preserves `user` ref, sets `status: LOCKED`
- [x] Unlock with correct PIN returns `true` and restores `ACTIVE`; wrong PIN returns `false`
- [x] Unlock by a different user clears the transaction draft

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)