### PR TITLE
feat: implement formatCurrency utility (AMSPOS-48)

### DIFF
--- a/autoshop-pos/src/utils/__tests__/formatCurrency.test.ts
+++ b/autoshop-pos/src/utils/__tests__/formatCurrency.test.ts
@@ -1,0 +1,29 @@
+import { formatPHP, parsePHP } from '../formatCurrency';
+
+describe('formatPHP', () => {
+  it('formats whole number', () => {
+    expect(formatPHP(1000)).toBe('₱1,000.00');
+  });
+
+  it('formats decimal', () => {
+    expect(formatPHP(1234.5)).toBe('₱1,234.50');
+  });
+
+  it('formats zero', () => {
+    expect(formatPHP(0)).toBe('₱0.00');
+  });
+
+  it('formats negative', () => {
+    expect(formatPHP(-50)).toBe('-₱50.00');
+  });
+});
+
+describe('parsePHP', () => {
+  it('parses formatted string back to number', () => {
+    expect(parsePHP('₱1,234.50')).toBe(1234.5);
+  });
+
+  it('returns NaN for invalid string', () => {
+    expect(parsePHP('abc')).toBeNaN();
+  });
+});

--- a/autoshop-pos/src/utils/formatCurrency.ts
+++ b/autoshop-pos/src/utils/formatCurrency.ts
@@ -1,0 +1,28 @@
+/**
+ * Formats a number as Philippine Peso.
+ * Examples:
+ *   formatPHP(1234.5)  → "₱1,234.50"
+ *   formatPHP(0)       → "₱0.00"
+ *   formatPHP(-50)     → "-₱50.00"
+ */
+export const formatPHP = (amount: number): string => {
+  const isNegative = amount < 0;
+  const abs = Math.abs(amount);
+
+  const formatted = abs.toLocaleString('en-PH', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  return isNegative ? `-₱${formatted}` : `₱${formatted}`;
+};
+
+/**
+ * Parses a formatted PHP string back to a number.
+ * Returns NaN if the string cannot be parsed.
+ * Example: parsePHP("₱1,234.50") → 1234.5
+ */
+export const parsePHP = (value: string): number => {
+  const cleaned = value.replace(/[₱,\s]/g, '');
+  return parseFloat(cleaned);
+};


### PR DESCRIPTION
## Summary
- Adds `formatPHP(amount)` — formats a number as Philippine Peso (e.g. `₱1,234.50`)
- Adds `parsePHP(value)` — parses a formatted PHP string back to a number
- 6 unit tests, all passing

## Test plan
- [x] `formatPHP` formats whole numbers, decimals, zero, and negatives correctly
- [x] `parsePHP` reverses `formatPHP` and returns `NaN` for invalid input
- [x] `npx jest formatCurrency` — all 6 tests pass

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)