### PR TITLE
feat: implement TransactionCard and LineItemRow components (AMSPOS-30)

### DIFF
--- a/autoshop-pos/src/components/transaction/LineItemRow.tsx
+++ b/autoshop-pos/src/components/transaction/LineItemRow.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Colors, Spacing, Typography } from '@constants/theme';
+import { formatPHP } from '@utils/formatCurrency';
+import type { LineItem } from '../../types';
+
+interface LineItemRowProps {
+  item: LineItem;
+}
+
+export const LineItemRow: React.FC<LineItemRowProps> = ({ item }) => (
+  <View style={styles.row}>
+    <View style={styles.left}>
+      <Text style={styles.name} numberOfLines={2}>{item.name}</Text>
+      <Text style={styles.meta}>
+        {formatPHP(item.unitPrice)} × {item.quantity}
+        {item.discountType ? `  −${item.discountType === 'PERCENTAGE' ? `${item.discountValue}%` : formatPHP(item.discountValue)}` : ''}
+      </Text>
+    </View>
+    <Text style={styles.total}>{formatPHP(item.total)}</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    paddingVertical: Spacing.sm,
+  },
+  left: { flex: 1, marginRight: Spacing.md },
+  name: { fontSize: Typography.base, color: Colors.black, marginBottom: 2 },
+  meta: { fontSize: Typography.sm, color: Colors.gray500 },
+  total: { fontSize: Typography.base, fontWeight: Typography.semiBold, color: Colors.black },
+});

--- a/autoshop-pos/src/components/transaction/PaymentMethodInput.tsx
+++ b/autoshop-pos/src/components/transaction/PaymentMethodInput.tsx
@@ -1,0 +1,1 @@
+export const PaymentMethodInput = () => null;

--- a/autoshop-pos/src/components/transaction/RefundBreakdown.tsx
+++ b/autoshop-pos/src/components/transaction/RefundBreakdown.tsx
@@ -1,0 +1,1 @@
+export const RefundBreakdown = () => null;

--- a/autoshop-pos/src/components/transaction/TransactionCard.tsx
+++ b/autoshop-pos/src/components/transaction/TransactionCard.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { AppBadge } from '@components/common/AppBadge';
+import { Colors, Spacing, Typography, BorderRadius } from '@constants/theme';
+import { formatPHP } from '@utils/formatCurrency';
+import type { Transaction } from '../../types';
+
+interface TransactionCardProps {
+  transaction: Transaction;
+  customerName?: string;
+  onPress: () => void;
+}
+
+const STATUS_VARIANT: Record<string, 'success' | 'warning' | 'danger' | 'neutral'> = {
+  IN_PROGRESS: 'warning',
+  FINALIZED: 'success',
+  VOIDED: 'danger',
+  CANCELLED: 'neutral',
+  RETURNED: 'neutral',
+};
+
+export const TransactionCard: React.FC<TransactionCardProps> = ({
+  transaction,
+  customerName,
+  onPress,
+}) => (
+  <TouchableOpacity style={styles.card} onPress={onPress} activeOpacity={0.7}>
+    <View style={styles.header}>
+      <Text style={styles.id} numberOfLines={1}>
+        #{transaction.id.slice(-8).toUpperCase()}
+      </Text>
+      <AppBadge
+        label={transaction.status.replace('_', ' ')}
+        variant={STATUS_VARIANT[transaction.status] ?? 'neutral'}
+      />
+    </View>
+    {customerName ? (
+      <Text style={styles.customer} numberOfLines={1}>{customerName}</Text>
+    ) : null}
+    <Text style={styles.amount}>{formatPHP(transaction.totalAmount)}</Text>
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: Colors.surface,
+    borderRadius: BorderRadius.md,
+    padding: Spacing.md,
+    marginBottom: Spacing.sm,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: Spacing.xs,
+  },
+  id: {
+    fontSize: Typography.sm,
+    color: Colors.gray500,
+    fontWeight: Typography.medium,
+  },
+  customer: {
+    fontSize: Typography.base,
+    color: Colors.gray900,
+    marginBottom: Spacing.xs,
+  },
+  amount: {
+    fontSize: Typography.lg,
+    fontWeight: Typography.bold,
+    color: Colors.black,
+  },
+});

--- a/autoshop-pos/src/components/transaction/index.ts
+++ b/autoshop-pos/src/components/transaction/index.ts
@@ -1,0 +1,4 @@
+export { TransactionCard } from './TransactionCard';
+export { LineItemRow } from './LineItemRow';
+export { PaymentMethodInput } from './PaymentMethodInput';
+export { RefundBreakdown } from './RefundBreakdown';


### PR DESCRIPTION
## Summary

- Adds `TransactionCard` — displays transaction ID, status badge (with correct color variant per status), optional customer name, and formatted total
- Adds `LineItemRow` — displays item name, qty × unit price, discount info, and formatted line total
- Adds `PaymentMethodInput` and `RefundBreakdown` stubs (to be fully implemented in Sprint 13)
- Exports all four via `src/components/transaction/index.ts`

Closes #16

## Test plan

- [ ] `TransactionCard` renders `#` + last 8 chars of ID uppercased
- [ ] Status badge shows `warning` for `IN_PROGRESS`, `success` for `FINALIZED`, `danger` for `VOIDED`, `neutral` for `CANCELLED`/`RETURNED`
- [ ] `LineItemRow` renders name, `formatPHP(unitPrice) × quantity`, discount info when present, and `formatPHP(total)`
- [ ] All monetary values use `formatPHP`
- [ ] TypeScript compiles with no errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)