### PR TITLE
feat: implement InitSetupScreen — Main Admin Creation (AMSPOS-13)

### DIFF
--- a/autoshop-pos/src/navigation/types.ts
+++ b/autoshop-pos/src/navigation/types.ts
@@ -1,0 +1,4 @@
+export type RootStackParamList = {
+  InitSetup: undefined;
+  PinLock: undefined;
+};

--- a/autoshop-pos/src/screens/auth/InitSetupScreen.tsx
+++ b/autoshop-pos/src/screens/auth/InitSetupScreen.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import { View, Text, ScrollView, StyleSheet, Alert } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { StackNavigationProp } from '@react-navigation/stack';
+import { AppInput } from '@components/common/AppInput';
+import { AppButton } from '@components/common/AppButton';
+import { Colors, Spacing, Typography } from '@constants/theme';
+import { createMainAdmin } from '@services/userService';
+import { isValidPin } from '@utils/pinHash';
+import { logEvent } from '@services/auditService';
+import type { RootStackParamList } from '@navigation/types';
+
+type Nav = StackNavigationProp<RootStackParamList, 'InitSetup'>;
+
+export const InitSetupScreen: React.FC = () => {
+  const navigation = useNavigation<Nav>();
+  const [displayName, setDisplayName] = useState('');
+  const [pin, setPin] = useState('');
+  const [confirmPin, setConfirmPin] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const validate = (): boolean => {
+    const newErrors: Record<string, string> = {};
+    if (!displayName.trim()) newErrors.displayName = 'Name is required.';
+    if (!isValidPin(pin)) newErrors.pin = 'PIN must be exactly 6 digits.';
+    if (pin !== confirmPin) newErrors.confirmPin = 'PINs do not match.';
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleCreate = async () => {
+    if (!validate()) return;
+    setLoading(true);
+    try {
+      const admin = await createMainAdmin(displayName.trim(), pin);
+      await logEvent({
+        userId: admin.id,
+        userName: admin.displayName,
+        actionType: 'LOGIN',
+        entityType: 'SESSION',
+        entityId: admin.id,
+        note: 'Initial setup — Main Admin created',
+      });
+      navigation.replace('PinLock');
+    } catch (e) {
+      Alert.alert('Setup Failed', e instanceof Error ? e.message : 'An error occurred.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+      <Text style={styles.title}>Welcome to AutoShop POS</Text>
+      <Text style={styles.subtitle}>
+        Set up the Main Admin account to get started. This can only be done once.
+      </Text>
+
+      <AppInput
+        label="Your Name"
+        value={displayName}
+        onChangeText={setDisplayName}
+        placeholder="e.g. Juan dela Cruz"
+        autoCapitalize="words"
+        error={errors.displayName}
+        containerStyle={styles.field}
+      />
+      <AppInput
+        label="Set PIN (6 digits)"
+        value={pin}
+        onChangeText={setPin}
+        keyboardType="numeric"
+        maxLength={6}
+        secureTextEntry
+        error={errors.pin}
+        containerStyle={styles.field}
+      />
+      <AppInput
+        label="Confirm PIN"
+        value={confirmPin}
+        onChangeText={setConfirmPin}
+        keyboardType="numeric"
+        maxLength={6}
+        secureTextEntry
+        error={errors.confirmPin}
+        containerStyle={styles.field}
+      />
+
+      <AppButton
+        label="Create Account"
+        onPress={handleCreate}
+        loading={loading}
+        fullWidth
+        style={styles.button}
+      />
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    padding: Spacing.xl,
+    justifyContent: 'center',
+    backgroundColor: Colors.background,
+  },
+  title: {
+    fontSize: Typography.xxl,
+    fontWeight: Typography.bold,
+    color: Colors.black,
+    marginBottom: Spacing.sm,
+  },
+  subtitle: {
+    fontSize: Typography.base,
+    color: Colors.gray500,
+    marginBottom: Spacing.xl,
+  },
+  field: { marginBottom: Spacing.md },
+  button: { marginTop: Spacing.lg },
+});

--- a/autoshop-pos/src/services/userService.ts
+++ b/autoshop-pos/src/services/userService.ts
@@ -1,0 +1,35 @@
+import { database } from './database';
+import { UserModel } from '../models/UserModel';
+import { hashPin, generateSalt } from '../utils/pinHash';
+import { PERMISSIONS } from '../constants/permissions';
+import type { User } from '../types';
+import { mapUserModel } from './authService';
+
+/**
+ * Creates the Main Admin account during initial setup.
+ * Should only be called once, when no users exist in the database.
+ * Grants all permissions to the Main Admin.
+ */
+export const createMainAdmin = async (displayName: string, pin: string): Promise<User> => {
+  const salt = await generateSalt();
+  const pinHash = await hashPin(pin, salt);
+
+  let createdModel: UserModel | null = null;
+
+  await database.write(async () => {
+    createdModel = await database.get<UserModel>('users').create((user) => {
+      user.displayName = displayName;
+      user.pinHash = pinHash;
+      user.pinSalt = salt;
+      user.permissions = Object.values(PERMISSIONS);
+      user.isMainAdmin = true;
+      user.isActive = true;
+      (user as any).createdAt = new Date();
+      (user as any).createdBy = 'SYSTEM';
+      (user as any).updatedAt = new Date();
+      (user as any).updatedBy = 'SYSTEM';
+    });
+  });
+
+  return mapUserModel(createdModel!);
+};


### PR DESCRIPTION
## Summary

- Adds `InitSetupScreen` shown once on first launch when no users exist in the database
- Creates `userService.createMainAdmin` which hashes the PIN, grants all permissions, and writes the user record
- Adds `RootStackParamList` navigation types for `InitSetup` and `PinLock` routes

## Changes

- `src/screens/auth/InitSetupScreen.tsx` — name + PIN + confirm PIN form with validation, audit log on success, navigates to `PinLock` via `navigation.replace`
- `src/services/userService.ts` — `createMainAdmin(displayName, pin)` hashes PIN with PBKDF2-SHA256, grants all permissions, returns mapped `User`
- `src/navigation/types.ts` — `RootStackParamList` type used by the navigator and this screen

## Test plan

- [ ] Screen renders name, PIN, and confirm PIN fields
- [ ] Validation: empty name shows error, PIN < 6 digits shows error, mismatched PINs shows error
- [ ] On valid submit, shows loading state while `createMainAdmin` runs
- [ ] On success, navigates to `PinLock` (no back navigation via `replace`)
- [ ] On error, shows `Alert.alert` with the error message
- [ ] No TypeScript errors

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)