### PR TITLE
feat(utils): add permission check utilities (AMSPOS-49)

### DIFF
--- a/autoshop-pos/src/utils/__tests__/permissions.test.ts
+++ b/autoshop-pos/src/utils/__tests__/permissions.test.ts
@@ -1,0 +1,21 @@
+import { hasPermission, requirePermission } from '../permissions';
+import type { User } from '../../types';
+
+const makeUser = (permissions: string[], isMainAdmin = false): User =>
+  ({ permissions, isMainAdmin, isActive: true } as User);
+
+describe('hasPermission', () => {
+  it('null user → false', () => expect(hasPermission(null, 'MANAGE_INVENTORY')).toBe(false));
+  it('mainAdmin → always true', () => expect(hasPermission(makeUser([], true), 'MANAGE_INVENTORY')).toBe(true));
+  it('user with permission → true', () => expect(hasPermission(makeUser(['MANAGE_INVENTORY']), 'MANAGE_INVENTORY')).toBe(true));
+  it('user without permission → false', () => expect(hasPermission(makeUser([]), 'MANAGE_INVENTORY')).toBe(false));
+});
+
+describe('requirePermission', () => {
+  it('throws for missing permission', () => {
+    expect(() => requirePermission(makeUser([]), 'MANAGE_USERS')).toThrow('Permission denied');
+  });
+  it('does not throw for valid permission', () => {
+    expect(() => requirePermission(makeUser(['MANAGE_USERS']), 'MANAGE_USERS')).not.toThrow();
+  });
+});

--- a/autoshop-pos/src/utils/permissions.ts
+++ b/autoshop-pos/src/utils/permissions.ts
@@ -1,0 +1,18 @@
+import type { User } from '../types';
+import type { Permission } from '../constants/permissions';
+
+export const hasPermission = (user: User | null, permission: Permission): boolean => {
+  if (!user) return false;
+  if (user.isMainAdmin) return true;
+  return user.permissions.includes(permission);
+};
+
+/**
+ * Throws an error if the user does not have the required permission.
+ * Use at the start of service functions that require authorization.
+ */
+export const requirePermission = (user: User | null, permission: Permission): void => {
+  if (!hasPermission(user, permission)) {
+    throw new Error(`Permission denied: ${permission} required.`);
+  }
+};


### PR DESCRIPTION
## Summary

- Adds `hasPermission(user, permission)` — returns `true` for Main Admin or users with the specified permission, `false` for null users or missing permission
- Adds `requirePermission(user, permission)` — throws a descriptive error for service-layer authorization enforcement
- Includes 6 unit tests covering all cases (null user, mainAdmin, user with/without permission)

## Test plan

- [x] `hasPermission` returns `false` for null user
- [x] `hasPermission` returns `true` for Main Admin regardless of permission
- [x] `hasPermission` returns `true` for user with matching permission
- [x] `hasPermission` returns `false` for user without permission
- [x] `requirePermission` throws `"Permission denied: <permission> required."` when missing
- [x] `requirePermission` does not throw when permission is present
- [x] All 6 tests pass

Closes AMSPOS-49

https://claude.ai/code/session_01DGdSEXoTnRGjWGch9ahevg