### PR TITLE
feat(hooks): implement useHasPermission hook (AMSPOS-17)

### DIFF
--- a/autoshop-pos/src/hooks/useHasPermission.ts
+++ b/autoshop-pos/src/hooks/useHasPermission.ts
@@ -1,0 +1,16 @@
+import { useSessionStore } from '@stores/sessionStore';
+import { hasPermission } from '@utils/permissions';
+import type { Permission } from '@constants/permissions';
+
+/**
+ * Returns true if the current user has the given permission.
+ * Use for conditional UI rendering (show/hide buttons, sections).
+ *
+ * Usage:
+ *   const canApplyDiscount = useHasPermission('APPLY_DISCOUNTS');
+ *   {canApplyDiscount && <AppButton label="Apply Discount" onPress={...} />}
+ */
+export const useHasPermission = (permission: Permission): boolean => {
+  const user = useSessionStore((s) => s.user);
+  return hasPermission(user, permission);
+};


### PR DESCRIPTION
## Summary

- Adds `useHasPermission(permission)` React hook in `src/hooks/useHasPermission.ts`
- Reads the current user from `sessionStore` reactively
- Delegates permission logic to the `hasPermission` utility (AMSPOS-49) — keeps business logic in one place
- Intended for conditional UI rendering (show/hide buttons, sections)

## Test plan

- [x] Returns `false` when `sessionStore.user` is null
- [x] Returns `true` for Main Admin regardless of permission
- [x] Returns `true` only when the permission is present in `user.permissions`
- [x] No TypeScript errors (`tsc --noEmit` passes clean)

Closes AMSPOS-17

https://claude.ai/code/session_01DGdSEXoTnRGjWGch9ahevg