### PR TITLE
feat(hooks): implement usePermissionGuard hook (AMSPOS-16)

### DIFF
--- a/autoshop-pos/src/hooks/usePermissionGuard.ts
+++ b/autoshop-pos/src/hooks/usePermissionGuard.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { Alert } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useSessionStore } from '@stores/sessionStore';
+import { hasPermission } from '@utils/permissions';
+import type { Permission } from '@constants/permissions';
+
+/**
+ * Screen-level permission guard.
+ * Call at the very top of a screen component (before any other hooks).
+ * Returns true when authorized, false when not.
+ *
+ * Usage:
+ *   const isAuthorized = usePermissionGuard('MANAGE_INVENTORY');
+ *   if (!isAuthorized) return null;
+ */
+export const usePermissionGuard = (permission: Permission): boolean => {
+  const user = useSessionStore((s) => s.user);
+  const navigation = useNavigation();
+  const isAuthorized = hasPermission(user, permission);
+
+  useEffect(() => {
+    if (!isAuthorized) {
+      navigation.goBack();
+      Alert.alert(
+        'Access Denied',
+        "You don't have permission to access this screen."
+      );
+    }
+  }, [isAuthorized, navigation]);
+
+  return isAuthorized;
+};


### PR DESCRIPTION
## Summary
- Adds `usePermissionGuard` hook at `src/hooks/usePermissionGuard.ts`
- Reads the current user from `useSessionStore` and checks the required permission via the `hasPermission` utility
- Automatically calls `navigation.goBack()` and shows an `Alert` when the user lacks the required permission
- Returns `true` when authorized, `false` otherwise — screens can render `null` early to prevent unauthorized effects from running
- Main admin (`isMainAdmin: true`) always returns `true` (via `hasPermission`)

Closes #23

## Test plan
- [ ] Verify hook returns `true` for a user with the required permission
- [ ] Verify hook returns `false`, navigates back, and shows Access Denied alert for a user without the permission
- [ ] Verify main admin always gets `true` regardless of permissions array