### PR TITLE
feat(navigation): implement RootNavigator with reactive first-launch …

### DIFF
--- a/autoshop-pos/App.tsx
+++ b/autoshop-pos/App.tsx
@@ -1,20 +1,14 @@
-import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import React from 'react';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { RootNavigator } from './src/navigation/RootNavigator';
 
 export default function App() {
   return (
-    <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
-      <StatusBar style="auto" />
-    </View>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <RootNavigator />
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/autoshop-pos/src/components/layout/AppListeners.tsx
+++ b/autoshop-pos/src/components/layout/AppListeners.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+/**
+ * Stub — full implementation is tracked in AMSPOS-19.
+ * Mounts as a sibling to Stack.Navigator inside RootNavigator.
+ */
+export const AppListeners: React.FC = () => null;

--- a/autoshop-pos/src/navigation/MainTabNavigator.tsx
+++ b/autoshop-pos/src/navigation/MainTabNavigator.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+/**
+ * Placeholder — full implementation is tracked in AMSPOS-22/23.
+ */
+export const MainTabNavigator: React.FC = () => (
+  <View style={styles.container}>
+    <Text style={styles.text}>Main App (Coming Soon)</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  text: { fontSize: 18, color: '#333' },
+});

--- a/autoshop-pos/src/navigation/RootNavigator.tsx
+++ b/autoshop-pos/src/navigation/RootNavigator.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import { createStackNavigator } from '@react-navigation/stack';
+import { NavigationContainer } from '@react-navigation/native';
+import { database } from '@services/database';
+import { useSessionStore } from '@stores/sessionStore';
+import { AppListeners } from '@components/layout/AppListeners';
+import { InitSetupScreen } from '@screens/auth/InitSetupScreen';
+import { PinLockScreen } from '@screens/auth/PinLockScreen';
+import { MainTabNavigator } from './MainTabNavigator';
+import type { RootStackParamList } from './types';
+
+const Stack = createStackNavigator<RootStackParamList>();
+
+export const RootNavigator: React.FC = () => {
+  const { status } = useSessionStore();
+  const [isFirstLaunch, setIsFirstLaunch] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const subscription = database
+      .get('users')
+      .query()
+      .observeCount()
+      .subscribe(count => {
+        setIsFirstLaunch(count === 0);
+      });
+    return () => subscription.unsubscribe();
+  }, []);
+
+  if (isFirstLaunch === null) {
+    return null;
+  }
+
+  return (
+    <NavigationContainer>
+      <AppListeners />
+      <Stack.Navigator screenOptions={{ headerShown: false, animationEnabled: false }}>
+        {isFirstLaunch ? (
+          <Stack.Screen name="InitSetup" component={InitSetupScreen} />
+        ) : status === 'ACTIVE' ? (
+          <Stack.Screen name="MainTabs" component={MainTabNavigator} />
+        ) : (
+          <Stack.Screen name="PinLock" component={PinLockScreen} />
+        )}
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+};


### PR DESCRIPTION
…detection (AMSPOS-21)

- Add RootNavigator using conditional stack screens driven by WatermelonDB observeCount() and sessionStore.status — no explicit navigate() calls needed
- Use observeCount() instead of one-shot fetchCount() so isFirstLaunch flips to false immediately when the first user is created, making PinLock and MainTabs available to the navigator without a restart
- Update App.tsx to wrap RootNavigator with GestureHandlerRootView and SafeAreaProvider
- Add AppListeners stub (AMSPOS-19) and MainTabNavigator placeholder pending their respective issues