### PR TITLE
feat(layout): implement AppListeners subscription lifecycle (AMSPOS-19)

### DIFF
--- a/autoshop-pos/src/components/layout/AppListeners.tsx
+++ b/autoshop-pos/src/components/layout/AppListeners.tsx
@@ -1,7 +1,45 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useSessionStore } from '@stores/sessionStore';
+import { useInventoryStore } from '@stores/inventoryStore';
+import { useCatalogStore } from '@stores/catalogStore';
+import { useOpenTransactionsStore } from '@stores/openTransactionsStore';
+import { useSettingsStore } from '@stores/settingsStore';
+import { useUserStore } from '@stores/userStore';
+import { useInactivityTimer } from '@hooks/useInactivityTimer';
+import { hasPermission } from '@utils/permissions';
 
 /**
- * Stub — full implementation is tracked in AMSPOS-19.
- * Mounts as a sibling to Stack.Navigator inside RootNavigator.
+ * Mounts as a sibling to the main navigation tree inside RootNavigator.
+ * Manages all Zustand store subscriptions tied to the active session.
  */
-export const AppListeners: React.FC = () => null;
+export const AppListeners: React.FC = () => {
+  const { status, user } = useSessionStore();
+
+  // Always mount inactivity timer — it self-activates only when status === 'ACTIVE'
+  useInactivityTimer();
+
+  useEffect(() => {
+    if (status === 'ACTIVE') {
+      // Subscribe all unconditional stores
+      useSettingsStore.getState().subscribe();
+      useInventoryStore.getState().subscribe();
+      useCatalogStore.getState().subscribe();
+      useOpenTransactionsStore.getState().subscribe();
+
+      // Conditional: userStore only for MANAGE_USERS permission
+      if (user && hasPermission(user, 'MANAGE_USERS')) {
+        useUserStore.getState().subscribe();
+      }
+    } else {
+      // Unsubscribe all on LOCKED or NONE
+      useSettingsStore.getState().unsubscribe();
+      useInventoryStore.getState().unsubscribe();
+      useCatalogStore.getState().unsubscribe();
+      useOpenTransactionsStore.getState().unsubscribe();
+      useUserStore.getState().unsubscribe();
+    }
+  }, [status, user]);
+
+  // This component renders nothing — it is a side-effect-only component
+  return null;
+};


### PR DESCRIPTION
## Summary
- Replaces the `AppListeners` stub with the full implementation
- Subscribes all Zustand stores (`settingsStore`, `inventoryStore`, `catalogStore`, `openTransactionsStore`) when `status === 'ACTIVE'`
- Conditionally subscribes `userStore` when the active user has `MANAGE_USERS` permission
- Unsubscribes all stores when `status` is `LOCKED` or `NONE`
- Mounts `useInactivityTimer` (self-activates only when session is active)
- Component renders `null` — side-effect only

Closes #25

## Test plan
- [ ] Login → verify stores subscribe (check console logs in store subscribe methods)
- [ ] Logout → verify stores unsubscribe
- [ ] Lock session → verify stores unsubscribe
- [ ] Login as user without MANAGE_USERS → verify `userStore` is NOT subscribed
- [ ] Login as user with MANAGE_USERS → verify `userStore` IS subscribed
- [ ] No TypeScript errors from this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)