### PR TITLE
fix(navigation): replace deprecated animationEnabled with animation: 'none'

### DIFF
--- a/autoshop-pos/src/navigation/RootNavigator.tsx
+++ b/autoshop-pos/src/navigation/RootNavigator.tsx
@@ -33,7 +33,7 @@ export const RootNavigator: React.FC = () => {
   return (
     <NavigationContainer>
       <AppListeners />
-      <Stack.Navigator screenOptions={{ headerShown: false, animationEnabled: false }}>
+      <Stack.Navigator screenOptions={{ headerShown: false, animation: 'none' }}>
         {isFirstLaunch ? (
           <Stack.Screen name="InitSetup" component={InitSetupScreen} />
         ) : status === 'ACTIVE' ? (


### PR DESCRIPTION
## Summary
- `animationEnabled` was removed in React Navigation v7
- Replaces it with `animation: 'none'` in `screenOptions` on `Stack.Navigator`
- Fixes the TypeScript error in `RootNavigator.tsx:36`

## Test plan
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] Screen transitions remain without animation on the emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)