### PR TITLE
feat(components): add SectionHeader, ProductCard, and StockBadge (AMSPOS-31, AMSPOS-32)

### DIFF
--- a/autoshop-pos/src/components/inventory/ProductCard.tsx
+++ b/autoshop-pos/src/components/inventory/ProductCard.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { StockBadge } from './StockBadge';
+import { Colors, Spacing, Typography, BorderRadius } from '@constants/theme';
+import { formatPHP } from '@utils/formatCurrency';
+import type { Product } from '@/types';
+
+interface ProductCardProps {
+  product: Product;
+  onPress: () => void;
+}
+
+export const ProductCard: React.FC<ProductCardProps> = ({ product, onPress }) => (
+  <TouchableOpacity style={styles.card} onPress={onPress} activeOpacity={0.7}>
+    <View style={styles.row}>
+      <Text style={styles.name} numberOfLines={2}>{product.name}</Text>
+      <Text style={styles.price}>{formatPHP(product.sellingPrice)}</Text>
+    </View>
+    <View style={styles.footer}>
+      <StockBadge
+        stockAvailable={product.stockAvailable}
+        lowStockThreshold={product.lowStockThreshold}
+      />
+      {product.barcode ? (
+        <Text style={styles.barcode} numberOfLines={1}>{product.barcode}</Text>
+      ) : null}
+    </View>
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: Colors.surface,
+    borderRadius: BorderRadius.md,
+    padding: Spacing.md,
+    marginBottom: Spacing.sm,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  row: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: Spacing.xs },
+  name: { flex: 1, fontSize: Typography.base, color: Colors.black, marginRight: Spacing.sm },
+  price: { fontSize: Typography.base, fontWeight: '600', color: Colors.primary },
+  footer: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  barcode: { fontSize: Typography.xs, color: Colors.gray500, maxWidth: 120 },
+});

--- a/autoshop-pos/src/components/inventory/StockBadge.tsx
+++ b/autoshop-pos/src/components/inventory/StockBadge.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Colors, Spacing, Typography, BorderRadius } from '@constants/theme';
+
+interface StockBadgeProps {
+  stockAvailable: number;
+  lowStockThreshold: number;
+}
+
+export const StockBadge: React.FC<StockBadgeProps> = ({ stockAvailable, lowStockThreshold }) => {
+  const isLow = stockAvailable <= lowStockThreshold && stockAvailable > 0;
+  const isOut = stockAvailable <= 0;
+
+  const bg = isOut ? Colors.dangerLight : isLow ? Colors.warningLight : Colors.successLight;
+  const textColor = isOut ? Colors.danger : isLow ? Colors.warning : Colors.success;
+  const label = isOut ? `Out (${stockAvailable})` : `${stockAvailable} in stock`;
+
+  return (
+    <View style={[styles.badge, { backgroundColor: bg }]}>
+      <Text style={[styles.label, { color: textColor }]}>{label}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  badge: {
+    paddingVertical: 2,
+    paddingHorizontal: Spacing.sm,
+    borderRadius: BorderRadius.full,
+    alignSelf: 'flex-start',
+  },
+  label: { fontSize: Typography.xs, fontWeight: '600' },
+});

--- a/autoshop-pos/src/components/inventory/index.ts
+++ b/autoshop-pos/src/components/inventory/index.ts
@@ -1,0 +1,2 @@
+export { ProductCard } from './ProductCard';
+export { StockBadge } from './StockBadge';

--- a/autoshop-pos/src/components/layout/ScreenWrapper.tsx
+++ b/autoshop-pos/src/components/layout/ScreenWrapper.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+/**
+ * Stub — full implementation is tracked in AMSPOS-27.
+ */
+export const ScreenWrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+  <>{children}</>;

--- a/autoshop-pos/src/components/layout/SectionHeader.tsx
+++ b/autoshop-pos/src/components/layout/SectionHeader.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { View, Text, StyleSheet, ViewStyle } from 'react-native';
+import { Colors, Spacing, Typography } from '@constants/theme';
+
+interface SectionHeaderProps {
+  title: string;
+  rightElement?: React.ReactNode;
+  style?: ViewStyle;
+}
+
+export const SectionHeader: React.FC<SectionHeaderProps> = ({
+  title,
+  rightElement,
+  style,
+}) => (
+  <View style={[styles.container, style]}>
+    <Text style={styles.title}>{title}</Text>
+    {rightElement ?? null}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    backgroundColor: Colors.gray100,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  title: {
+    fontSize: Typography.sm,
+    fontWeight: '600',
+    color: Colors.gray700,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+});

--- a/autoshop-pos/src/components/layout/index.ts
+++ b/autoshop-pos/src/components/layout/index.ts
@@ -1,0 +1,3 @@
+export { ScreenWrapper } from './ScreenWrapper'; // stub for now — implemented in AMSPOS-27
+export { SectionHeader } from './SectionHeader';
+export { AppListeners } from './AppListeners';


### PR DESCRIPTION
## Summary
- **SectionHeader** (`layout/SectionHeader.tsx`) — uppercase section title bar with optional `rightElement` slot; used in list screens to divide content sections
- **StockBadge** (`inventory/StockBadge.tsx`) — color-coded pill showing stock count: green = normal, yellow = low (≤ threshold but > 0), red = out (≤ 0)
- **ProductCard** (`inventory/ProductCard.tsx`) — tappable card rendering product name, formatted PHP price, `StockBadge`, and barcode (when set)
- **ScreenWrapper stub** (`layout/ScreenWrapper.tsx`) — minimal stub to satisfy the `layout/index.ts` barrel export until AMSPOS-27 is implemented
- Barrel exports added for both `layout/` and `inventory/` component directories

Closes #26
Closes #27

## Test plan
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] Import `SectionHeader` into a screen and verify it renders uppercase title with gray background
- [ ] Pass a `rightElement` to `SectionHeader` and verify it appears on the right
- [ ] Render `StockBadge` with `stockAvailable > lowStockThreshold` → green
- [ ] Render `StockBadge` with `stockAvailable <= lowStockThreshold && > 0` → yellow
- [ ] Render `StockBadge` with `stockAvailable <= 0` → red
- [ ] Render `ProductCard` with a barcode → barcode text visible
- [ ] Render `ProductCard` without a barcode → no barcode text rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)