### PR TITLE
feat(navigation): add full typed param lists and screen prop helpers (AMSPOS-20)

### DIFF
--- a/autoshop-pos/src/navigation/types.ts
+++ b/autoshop-pos/src/navigation/types.ts
@@ -1,5 +1,105 @@
+import type { StackScreenProps } from '@react-navigation/stack';
+import type { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
+import type { CompositeScreenProps, NavigatorScreenParams } from '@react-navigation/native';
+
+// ─── Root Stack ───────────────────────────────────────────────────────────────
+
 export type RootStackParamList = {
   InitSetup: undefined;
   PinLock: undefined;
-  MainTabs: undefined;
+  MainTabs: NavigatorScreenParams<MainTabParamList>;
 };
+
+// ─── Main Tab Navigator ───────────────────────────────────────────────────────
+
+export type MainTabParamList = {
+  Dashboard: undefined;
+  Transactions: NavigatorScreenParams<TransactionsStackParamList>;
+  Inventory: NavigatorScreenParams<InventoryStackParamList>;
+  Admin: NavigatorScreenParams<AdminStackParamList>;
+};
+
+// ─── Transactions Stack ───────────────────────────────────────────────────────
+
+export type TransactionsStackParamList = {
+  TransactionList: undefined;
+  NewTransaction: undefined;
+  TransactionDetail: { transactionId: string };
+  Payment: { transactionId: string };
+  Receipt: { transactionId: string };
+  TransactionHistoryDetail: { transactionId: string };
+  VoidTransaction: { transactionId: string };
+  ReturnTransaction: { transactionId: string };
+};
+
+// ─── Inventory Stack ──────────────────────────────────────────────────────────
+
+export type InventoryStackParamList = {
+  InventoryList: undefined;
+  ProductForm: { productId?: string };    // undefined = create; string = edit
+  ServiceForm: { serviceId?: string };
+  CategoryList: undefined;
+  SupplierList: undefined;
+  AddOnCatalog: undefined;
+};
+
+// ─── Admin Stack ──────────────────────────────────────────────────────────────
+
+export type AdminStackParamList = {
+  AdminMenu: undefined;
+  Reports: undefined;
+  AuditLog: undefined;
+  CustomerList: undefined;
+  CustomerDetail: { customerId: string };
+  CustomerForm: { customerId?: string };
+  VehicleDetail: { vehicleId: string };
+  VehicleForm: { vehicleId?: string; customerId: string };
+  UserList: undefined;
+  UserForm: { userId?: string };
+  Settings: undefined;
+  ChangeOwnPin: undefined;
+};
+
+// ─── Modal Screens (presented over any stack) ────────────────────────────────
+
+export type ModalParamList = {
+  BarcodeScanner: {
+    onScan: (barcode: string) => void;
+  };
+  DiscountPicker: {
+    lineItemId: string;
+    currentDiscountType: string;
+    currentDiscountValue: number;
+    onApply: (type: 'FIXED' | 'PERCENTAGE', value: number) => void;
+  };
+  AddOnPicker: {
+    lineItemId: string;
+    onApply: (name: string, amount: number, isOnTheFly: boolean, addOnId?: string) => void;
+  };
+  CustomerSearch: {
+    onSelect: (customerId: string, vehicleId?: string) => void;
+  };
+};
+
+// ─── Screen prop helpers ──────────────────────────────────────────────────────
+
+export type RootStackScreenProps<T extends keyof RootStackParamList> =
+  StackScreenProps<RootStackParamList, T>;
+
+export type TransactionsStackScreenProps<T extends keyof TransactionsStackParamList> =
+  CompositeScreenProps<
+    StackScreenProps<TransactionsStackParamList, T>,
+    BottomTabScreenProps<MainTabParamList>
+  >;
+
+export type InventoryStackScreenProps<T extends keyof InventoryStackParamList> =
+  CompositeScreenProps<
+    StackScreenProps<InventoryStackParamList, T>,
+    BottomTabScreenProps<MainTabParamList>
+  >;
+
+export type AdminStackScreenProps<T extends keyof AdminStackParamList> =
+  CompositeScreenProps<
+    StackScreenProps<AdminStackParamList, T>,
+    BottomTabScreenProps<MainTabParamList>
+  >;


### PR DESCRIPTION
## Summary

- Replaced the minimal `RootStackParamList` stub in `src/navigation/types.ts` with the full set of typed param lists covering every navigator and screen in the app
- Added `MainTabParamList`, `TransactionsStackParamList`, `InventoryStackParamList`, `AdminStackParamList`, and `ModalParamList`
- Exported composite screen prop helpers (`RootStackScreenProps`, `TransactionsStackScreenProps`, `InventoryStackScreenProps`, `AdminStackScreenProps`) so screen components and `useNavigation` calls can reference strongly-typed props
- `MainTabs` in `RootStackParamList` now uses `NavigatorScreenParams<MainTabParamList>` instead of `undefined`

## What is testable via emulator

- No runtime-visible changes in this PR — it is a types-only file. TypeScript will catch any screen component that is not aligned with the new param lists at compile time.
- Verify the app still builds and navigates correctly: launch the emulator, confirm `InitSetup` → `PinLock` → `MainTabs` flow works without type errors or crashes.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)