### PR TITLE
fix(navigation): pass empty params object to replace('MainTabs')

### DIFF
--- a/autoshop-pos/src/screens/auth/PinLockScreen.tsx
+++ b/autoshop-pos/src/screens/auth/PinLockScreen.tsx
@@ -66,7 +66,7 @@ export const PinLockScreen: React.FC = () => {
         });
       }
 
-      navigation.replace('MainTabs');
+      navigation.replace('MainTabs', {});
     } catch (e) {
       Alert.alert('Error', e instanceof Error ? e.message : 'An error occurred.');
     } finally {


### PR DESCRIPTION
NavigatorScreenParams<MainTabParamList> is not undefined, so TypeScript requires a second argument. Passing {} satisfies the type since all nested tab params are optional.