### PR TITLE
feat(ui): add EmptyState to TransactionList and InventoryList screens (AMSPOS-88)

### DIFF
--- a/autoshop-pos/src/screens/inventory/InventoryListScreen.tsx
+++ b/autoshop-pos/src/screens/inventory/InventoryListScreen.tsx
@@ -181,9 +181,12 @@ export const InventoryListScreen: React.FC<Props> = ({ navigation }) => {
               filteredProducts.length === 0 && styles.listEmpty,
             ]}
             ListEmptyComponent={
-              query
-                ? <EmptyState title="No products found" subtitle="Try a different name or barcode." />
-                : <EmptyState title="No products found" />
+              loading ? null : (
+                <EmptyState
+                  title="No Products Found"
+                  subtitle="No products found. Tap + to add your first product."
+                />
+              )
             }
           />
         </View>
@@ -207,9 +210,12 @@ export const InventoryListScreen: React.FC<Props> = ({ navigation }) => {
               filteredServices.length === 0 && styles.listEmpty,
             ]}
             ListEmptyComponent={
-              query
-                ? <EmptyState title="No services found" subtitle="Try a different name." />
-                : <EmptyState title="No service items found" />
+              loading ? null : (
+                <EmptyState
+                  title="No Services Found"
+                  subtitle="No services found. Tap + to add your first service."
+                />
+              )
             }
           />
         </View>

--- a/autoshop-pos/src/screens/transactions/TransactionListScreen.tsx
+++ b/autoshop-pos/src/screens/transactions/TransactionListScreen.tsx
@@ -14,6 +14,7 @@ import { useHasPermission } from '@hooks/useHasPermission';
 import { PERMISSIONS } from '@constants/permissions';
 import { ScreenWrapper } from '@components/layout/ScreenWrapper';
 import { TransactionCard } from '@components/transaction/TransactionCard';
+import { EmptyState } from '@components/common/EmptyState';
 import { Colors, Spacing, Typography, BorderRadius } from '@constants/theme';
 import { formatPHP } from '@utils/formatCurrency';
 import { database } from '@services/database';
@@ -142,7 +143,10 @@ export const TransactionListScreen: React.FC<Props> = ({ navigation }) => {
             renderItem={renderInProgressItem}
             contentContainerStyle={styles.listContent}
             ListEmptyComponent={
-              <Text style={styles.empty}>No active transactions</Text>
+              <EmptyState
+                title="No Transactions"
+                subtitle="No in-progress transactions. Tap + to start one."
+              />
             }
             scrollEnabled={false}
           />


### PR DESCRIPTION
## Summary

- Replaces inline `<Text>` empty state in `TransactionListScreen` with the shared `EmptyState` component (title: "No Transactions", subtitle: "No in-progress transactions. Tap + to start one.")
- Updates `InventoryListScreen` products and services `ListEmptyComponent` to use spec-compliant titles/subtitles
- Adds `loading` guard on `InventoryListScreen` so `EmptyState` is not rendered while data is still loading
- `TransactionDetailScreen` already had `EmptyState` implemented correctly — no changes needed

Closes #77

## Test plan

- [ ] **TransactionListScreen — empty in-progress list**: Log in and ensure there are no in-progress transactions. Navigate to Transactions tab. The "In Progress" section should show "No Transactions / No in-progress transactions. Tap + to start one." instead of a plain text message.
- [ ] **TransactionListScreen — loading guard**: The empty state should NOT flash briefly while the list loads on first render.
- [ ] **TransactionDetailScreen — no line items**: Open or create a new transaction. Before adding any items, the line items area should show "No Items Added / No items added yet. Search for products or services above."
- [ ] **InventoryListScreen — empty products**: Clear all products (or use a fresh DB). Navigate to Inventory > Products tab. Should show "No Products Found / No products found. Tap + to add your first product."
- [ ] **InventoryListScreen — loading guard**: Empty state should NOT appear while the inventory is loading (LoadingOverlay should be the only indicator).
- [ ] **InventoryListScreen — services tab**: Navigate to Services tab with no services. Should show "No Services Found / No services found. Tap + to add your first service."
- [ ] No TypeScript errors in the modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)