### PR TITLE
feat(admin): implement CustomerDetailScreen (AMSPOS-60)

### DIFF
--- a/autoshop-pos/src/screens/admin/CustomerDetailScreen.tsx
+++ b/autoshop-pos/src/screens/admin/CustomerDetailScreen.tsx
@@ -1,8 +1,373 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useCallback, useState } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+} from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import { ScreenWrapper } from '@components/layout/ScreenWrapper';
+import { SectionHeader } from '@components/layout/SectionHeader';
+import { AppBadge } from '@components/common/AppBadge';
+import { AppButton } from '@components/common/AppButton';
+import { EmptyState } from '@components/common/EmptyState';
+import { observeVehiclesForCustomer } from '@services/vehicleService';
+import { observeTransactionsForCustomer } from '@services/transactionService';
+import { database } from '@services/database';
+import { CustomerModel } from '../../models/CustomerModel';
+import { formatPHP } from '@utils/formatCurrency';
+import { Colors, Spacing, Typography } from '@constants/theme';
+import type { Customer, Vehicle, Transaction, TransactionStatus } from '../../types';
+import type { AdminStackScreenProps } from '@navigation/types';
 
-export const CustomerDetailScreen: React.FC = () => (
-  <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-    <Text>Customer (Coming Soon)</Text>
-  </View>
-);
+type Props = AdminStackScreenProps<'CustomerDetail'>;
+
+type BadgeVariant = 'success' | 'warning' | 'danger' | 'neutral' | 'primary';
+
+const STATUS_LABEL: Record<TransactionStatus, string> = {
+  IN_PROGRESS: 'In Progress',
+  FINALIZED: 'Finalized',
+  VOIDED: 'Voided',
+  CANCELLED: 'Cancelled',
+  RETURNED: 'Returned',
+};
+
+const STATUS_BADGE_VARIANT: Record<TransactionStatus, BadgeVariant> = {
+  IN_PROGRESS: 'primary',
+  FINALIZED: 'success',
+  VOIDED: 'danger',
+  CANCELLED: 'neutral',
+  RETURNED: 'warning',
+};
+
+const HISTORY_STATUSES: TransactionStatus[] = ['FINALIZED', 'VOIDED', 'RETURNED'];
+
+const formatDate = (date: Date | number): string => {
+  const d = typeof date === 'number' ? new Date(date) : date;
+  return d.toLocaleDateString('en-PH', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
+export const CustomerDetailScreen: React.FC<Props> = ({ route, navigation }) => {
+  const { customerId } = route.params;
+
+  const [customer, setCustomer] = useState<Customer | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [vehicles, setVehicles] = useState<Vehicle[]>([]);
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+
+  const loadCustomer = useCallback(async (id: string) => {
+    try {
+      const model = await database.get<CustomerModel>('customers').find(id);
+      setCustomer({
+        id: model.id,
+        type: model.type,
+        name: model.name,
+        phone: model.phone,
+        email: model.email,
+        isActive: model.isActive,
+        createdAt: model.createdAt,
+        createdBy: model.createdBy,
+      });
+    } catch {
+      setCustomer(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      setLoading(true);
+      loadCustomer(customerId);
+
+      const vehicleSub = observeVehiclesForCustomer(customerId).subscribe((models) => {
+        setVehicles(
+          models.map((v) => ({
+            id: v.id,
+            customerId: v.customerId,
+            make: v.make,
+            model: v.model,
+            color: v.color,
+            plateNumber: v.plateNumber,
+            createdAt: v.createdAt,
+            createdBy: v.createdBy,
+          }))
+        );
+      });
+
+      const txSub = observeTransactionsForCustomer(customerId).subscribe((models) => {
+        const history = models
+          .filter((t) => (HISTORY_STATUSES as string[]).includes(t.status))
+          .map((t) => ({
+            id: t.id,
+            status: t.status as TransactionStatus,
+            customerId: t.customerId,
+            vehicleId: t.vehicleId,
+            cashierId: t.cashierId,
+            subtotal: t.subtotal,
+            totalVat: t.totalVat,
+            totalAmount: t.totalAmount,
+            changeDue: t.changeDue,
+            hasReturn: t.hasReturn,
+            originalTransactionId: t.originalTransactionId,
+            voidReason: t.voidReason,
+            voidedBy: t.voidedBy,
+            voidedAt: t.voidedAt,
+            returnReason: t.returnReason,
+            returnedBy: t.returnedBy,
+            returnedAt: t.returnedAt,
+            createdAt: t.createdAt,
+            createdBy: t.createdBy,
+            finalizedAt: t.finalizedAt,
+            finalizedBy: t.finalizedBy,
+            lineItems: [],
+            payments: [],
+          }));
+        setTransactions(history);
+      });
+
+      return () => {
+        vehicleSub.unsubscribe();
+        txSub.unsubscribe();
+      };
+    }, [customerId, loadCustomer])
+  );
+
+  if (loading) {
+    return (
+      <ScreenWrapper>
+        <ActivityIndicator testID="loading-indicator" style={styles.loader} color={Colors.primary} />
+      </ScreenWrapper>
+    );
+  }
+
+  if (!customer) {
+    return (
+      <ScreenWrapper>
+        <Text style={styles.errorText}>Customer not found.</Text>
+      </ScreenWrapper>
+    );
+  }
+
+  const displayName = customer.type === 'WALKIN' ? customer.name || 'Walk-in' : customer.name;
+
+  return (
+    <ScreenWrapper>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+
+        {/* ─── Section 1: Customer Info ───────────────────────────────────── */}
+        <SectionHeader
+          title="Customer Info"
+          rightElement={
+            <AppButton
+              label="Edit"
+              variant="ghost"
+              size="sm"
+              onPress={() => navigation.navigate('CustomerForm', { customerId })}
+            />
+          }
+        />
+        <View style={styles.section}>
+          <View style={styles.nameRow}>
+            <Text style={styles.customerName}>{displayName}</Text>
+            <AppBadge
+              label={customer.type === 'WALKIN' ? 'Walk-in' : 'Named'}
+              variant={customer.type === 'WALKIN' ? 'neutral' : 'primary'}
+            />
+          </View>
+          {customer.phone ? (
+            <View style={styles.metaRow}>
+              <Text style={styles.metaLabel}>Phone</Text>
+              <Text style={styles.metaValue}>{customer.phone}</Text>
+            </View>
+          ) : null}
+          {customer.email ? (
+            <View style={styles.metaRow}>
+              <Text style={styles.metaLabel}>Email</Text>
+              <Text style={styles.metaValue}>{customer.email}</Text>
+            </View>
+          ) : null}
+        </View>
+
+        {/* ─── Section 2: Vehicles ────────────────────────────────────────── */}
+        <SectionHeader
+          title="Vehicles"
+          rightElement={
+            <AppButton
+              label="Add Vehicle"
+              variant="ghost"
+              size="sm"
+              onPress={() => navigation.navigate('VehicleForm', { customerId })}
+            />
+          }
+        />
+        {vehicles.length === 0 ? (
+          <View style={styles.emptyWrapper}>
+            <EmptyState title="No Vehicles" subtitle="No vehicles linked to this customer." />
+          </View>
+        ) : (
+          <View style={styles.listSection}>
+            {vehicles.map((vehicle) => (
+              <TouchableOpacity
+                key={vehicle.id}
+                testID={`vehicle-row-${vehicle.id}`}
+                style={styles.listRow}
+                activeOpacity={0.7}
+                onPress={() => navigation.navigate('VehicleDetail', { vehicleId: vehicle.id })}
+              >
+                <Text style={styles.vehicleText}>
+                  {vehicle.make} {vehicle.model}
+                  {vehicle.color ? ` (${vehicle.color})` : ''}
+                  {vehicle.plateNumber ? ` — ${vehicle.plateNumber}` : ''}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        )}
+
+        {/* ─── Section 3: Transaction History ────────────────────────────── */}
+        <SectionHeader title="Transaction History" />
+        {transactions.length === 0 ? (
+          <View style={styles.emptyWrapper}>
+            <EmptyState title="No Transactions" subtitle="No transaction history for this customer." />
+          </View>
+        ) : (
+          <View style={styles.listSection}>
+            {transactions.map((txn) => (
+              <TouchableOpacity
+                key={txn.id}
+                testID={`txn-row-${txn.id}`}
+                style={styles.listRow}
+                activeOpacity={0.7}
+                onPress={() =>
+                  navigation.navigate('Transactions', {
+                    screen: 'TransactionHistoryDetail',
+                    params: { transactionId: txn.id },
+                  })
+                }
+              >
+                <View style={styles.txnRow}>
+                  <View style={styles.txnLeft}>
+                    <Text style={styles.txnDate}>
+                      {formatDate(txn.finalizedAt ?? txn.createdAt)}
+                    </Text>
+                    <Text style={styles.txnTotal}>{formatPHP(txn.totalAmount)}</Text>
+                  </View>
+                  <AppBadge
+                    label={STATUS_LABEL[txn.status]}
+                    variant={STATUS_BADGE_VARIANT[txn.status]}
+                  />
+                </View>
+              </TouchableOpacity>
+            ))}
+          </View>
+        )}
+
+      </ScrollView>
+    </ScreenWrapper>
+  );
+};
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  loader: { marginTop: Spacing.xxl },
+  errorText: {
+    fontSize: Typography.base,
+    color: Colors.gray500,
+    textAlign: 'center',
+    marginTop: Spacing.xxl,
+  },
+  scrollContent: {
+    paddingBottom: Spacing.xl,
+  },
+
+  // Customer info section
+  section: {
+    backgroundColor: Colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.md,
+    gap: Spacing.sm,
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  customerName: {
+    fontSize: Typography.xl,
+    fontWeight: Typography.bold,
+    color: Colors.black,
+    flex: 1,
+    marginRight: Spacing.sm,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  metaLabel: {
+    fontSize: Typography.sm,
+    color: Colors.gray500,
+  },
+  metaValue: {
+    fontSize: Typography.sm,
+    color: Colors.gray900,
+    fontWeight: Typography.medium,
+  },
+
+  // List sections
+  listSection: {
+    backgroundColor: Colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  listRow: {
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm + 2,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+
+  // Vehicle row
+  vehicleText: {
+    fontSize: Typography.base,
+    color: Colors.gray900,
+  },
+
+  // Transaction row
+  txnRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  txnLeft: {
+    flex: 1,
+    marginRight: Spacing.sm,
+  },
+  txnDate: {
+    fontSize: Typography.sm,
+    color: Colors.gray500,
+  },
+  txnTotal: {
+    fontSize: Typography.base,
+    fontWeight: Typography.semiBold,
+    color: Colors.black,
+    marginTop: 2,
+  },
+
+  // Empty state wrapper
+  emptyWrapper: {
+    backgroundColor: Colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+    paddingVertical: Spacing.xl,
+  },
+});

--- a/autoshop-pos/src/screens/admin/__tests__/CustomerDetailScreen.test.tsx
+++ b/autoshop-pos/src/screens/admin/__tests__/CustomerDetailScreen.test.tsx
@@ -1,0 +1,397 @@
+import React from 'react';
+import { render, act, fireEvent } from '@testing-library/react-native';
+import { CustomerDetailScreen } from '../CustomerDetailScreen';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockVehicleSub = { unsubscribe: jest.fn() };
+const mockTxSub = { unsubscribe: jest.fn() };
+
+jest.mock('@services/vehicleService', () => ({
+  observeVehiclesForCustomer: jest.fn(() => ({
+    subscribe: jest.fn((cb: (v: unknown[]) => void) => {
+      cb([]);
+      return mockVehicleSub;
+    }),
+  })),
+}));
+
+jest.mock('@services/transactionService', () => ({
+  observeTransactionsForCustomer: jest.fn(() => ({
+    subscribe: jest.fn((cb: (t: unknown[]) => void) => {
+      cb([]);
+      return mockTxSub;
+    }),
+  })),
+}));
+
+jest.mock('@services/database', () => ({
+  database: {
+    get: jest.fn(() => ({
+      find: jest.fn().mockResolvedValue(null),
+    })),
+  },
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: (cb: () => (() => void) | void) => {
+    const React = require('react');
+    React.useEffect(cb, []);
+  },
+}));
+
+jest.mock('@components/layout/ScreenWrapper', () => ({
+  ScreenWrapper: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@components/layout/SectionHeader', () => ({
+  SectionHeader: ({ title, rightElement }: { title: string; rightElement?: React.ReactNode }) => {
+    const { View, Text } = require('react-native');
+    return (
+      <View>
+        <Text testID={`section-header-${title}`}>{title}</Text>
+        {rightElement ?? null}
+      </View>
+    );
+  },
+}));
+
+jest.mock('@components/common/AppBadge', () => ({
+  AppBadge: ({ label }: { label: string }) => {
+    const { Text } = require('react-native');
+    return <Text testID={`badge-${label}`}>{label}</Text>;
+  },
+}));
+
+jest.mock('@components/common/AppButton', () => ({
+  AppButton: ({ label, onPress }: { label: string; onPress: () => void }) => {
+    const { Text } = require('react-native');
+    return <Text testID={`btn-${label}`} onPress={onPress}>{label}</Text>;
+  },
+}));
+
+jest.mock('@components/common/EmptyState', () => ({
+  EmptyState: ({ title }: { title: string }) => {
+    const { Text } = require('react-native');
+    return <Text testID={`empty-${title}`}>{title}</Text>;
+  },
+}));
+
+import { observeVehiclesForCustomer } from '@services/vehicleService';
+import { observeTransactionsForCustomer } from '@services/transactionService';
+import { database } from '@services/database';
+
+const mockObserveVehicles = observeVehiclesForCustomer as jest.Mock;
+const mockObserveTxns = observeTransactionsForCustomer as jest.Mock;
+const mockDatabase = database as jest.Mocked<typeof database>;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeNavigation(overrides: Record<string, jest.Mock> = {}) {
+  return { navigate: jest.fn(), goBack: jest.fn(), ...overrides };
+}
+
+function makeRoute(customerId = 'cust-1') {
+  return { params: { customerId } };
+}
+
+function makeCustomerModel(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'cust-1',
+    type: 'NAMED',
+    name: 'Juan dela Cruz',
+    phone: '09171234567',
+    email: 'juan@example.com',
+    isActive: true,
+    createdAt: new Date('2025-01-01'),
+    createdBy: 'user-1',
+    ...overrides,
+  };
+}
+
+function makeVehicleModel(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'veh-1',
+    customerId: 'cust-1',
+    make: 'Toyota',
+    model: 'Vios',
+    color: 'White',
+    plateNumber: 'ABC 1234',
+    createdAt: new Date('2025-01-01'),
+    createdBy: 'user-1',
+    ...overrides,
+  };
+}
+
+function makeTxnModel(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'txn-1',
+    status: 'FINALIZED',
+    customerId: 'cust-1',
+    vehicleId: '',
+    cashierId: 'user-1',
+    subtotal: 1000,
+    totalVat: 0,
+    totalAmount: 1000,
+    changeDue: 0,
+    hasReturn: false,
+    originalTransactionId: '',
+    voidReason: '',
+    voidedBy: '',
+    voidedAt: 0,
+    returnReason: '',
+    returnedBy: '',
+    returnedAt: 0,
+    createdAt: new Date('2025-01-15'),
+    createdBy: 'user-1',
+    finalizedAt: new Date('2025-01-15').getTime(),
+    finalizedBy: 'user-1',
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('CustomerDetailScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (mockDatabase.get as jest.Mock).mockReturnValue({
+      find: jest.fn().mockRejectedValue(new Error('not found')),
+    });
+
+    mockObserveVehicles.mockReturnValue({
+      subscribe: jest.fn((cb: (v: unknown[]) => void) => { cb([]); return mockVehicleSub; }),
+    });
+
+    mockObserveTxns.mockReturnValue({
+      subscribe: jest.fn((cb: (t: unknown[]) => void) => { cb([]); return mockTxSub; }),
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows ActivityIndicator while loading', () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn(() => new Promise(() => {})),
+      });
+      const { getByTestId } = render(
+        <CustomerDetailScreen route={makeRoute() as any} navigation={makeNavigation() as any} />
+      );
+      expect(getByTestId('loading-indicator')).toBeTruthy();
+    });
+
+    it('shows error text when customer is not found', async () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn().mockRejectedValue(new Error('not found')),
+      });
+      const { getByText } = render(
+        <CustomerDetailScreen route={makeRoute() as any} navigation={makeNavigation() as any} />
+      );
+      await act(async () => {});
+      expect(getByText('Customer not found.')).toBeTruthy();
+    });
+  });
+
+  describe('customer info section', () => {
+    it('displays customer name and Named badge', async () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn().mockResolvedValue(makeCustomerModel({ type: 'NAMED', name: 'Juan dela Cruz' })),
+      });
+      const { getByText, getByTestId } = render(
+        <CustomerDetailScreen route={makeRoute() as any} navigation={makeNavigation() as any} />
+      );
+      await act(async () => {});
+      expect(getByText('Juan dela Cruz')).toBeTruthy();
+      expect(getByTestId('badge-Named')).toBeTruthy();
+    });
+
+    it('displays Walk-in badge for WALKIN customer type', async () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn().mockResolvedValue(makeCustomerModel({ type: 'WALKIN', name: 'Walk-in Customer' })),
+      });
+      const { getByTestId } = render(
+        <CustomerDetailScreen route={makeRoute() as any} navigation={makeNavigation() as any} />
+      );
+      await act(async () => {});
+      expect(getByTestId('badge-Walk-in')).toBeTruthy();
+    });
+
+    it('shows phone and email when present', async () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn().mockResolvedValue(makeCustomerModel({ phone: '09171234567', email: 'juan@example.com' })),
+      });
+      const { getByText } = render(
+        <CustomerDetailScreen route={makeRoute() as any} navigation={makeNavigation() as any} />
+      );
+      await act(async () => {});
+      expect(getByText('09171234567')).toBeTruthy();
+      expect(getByText('juan@example.com')).toBeTruthy();
+    });
+
+    it('navigates to CustomerForm with customerId on Edit button press', async () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn().mockResolvedValue(makeCustomerModel()),
+      });
+      const navigate = jest.fn();
+      const { getByTestId } = render(
+        <CustomerDetailScreen route={makeRoute('cust-1') as any} navigation={makeNavigation({ navigate }) as any} />
+      );
+      await act(async () => {});
+      fireEvent.press(getByTestId('btn-Edit'));
+      expect(navigate).toHaveBeenCalledWith('CustomerForm', { customerId: 'cust-1' });
+    });
+  });
+
+  describe('vehicles section', () => {
+    it('shows EmptyState when no vehicles', async () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn().mockResolvedValue(makeCustomerModel()),
+      });
+      mockObserveVehicles.mockReturnValue({
+        subscribe: jest.fn((cb: (v: unknown[]) => void) => { cb([]); return mockVehicleSub; }),
+      });
+      const { getByTestId } = render(
+        <CustomerDetailScreen route={makeRoute() as any} navigation={makeNavigation() as any} />
+      );
+      await act(async () => {});
+      expect(getByTestId('empty-No Vehicles')).toBeTruthy();
+    });
+
+    it('renders vehicle rows with make, model, color, and plate', async () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn().mockResolvedValue(makeCustomerModel()),
+      });
+      mockObserveVehicles.mockReturnValue({
+        subscribe: jest.fn((cb: (v: unknown[]) => void) => {
+          cb([makeVehicleModel()]);
+          return mockVehicleSub;
+        }),
+      });
+      const { getByText } = render(
+        <CustomerDetailScreen route={makeRoute() as any} navigation={makeNavigation() as any} />
+      );
+      await act(async () => {});
+      expect(getByText('Toyota Vios (White) — ABC 1234')).toBeTruthy();
+    });
+
+    it('navigates to VehicleDetail on vehicle row press', async () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn().mockResolvedValue(makeCustomerModel()),
+      });
+      mockObserveVehicles.mockReturnValue({
+        subscribe: jest.fn((cb: (v: unknown[]) => void) => {
+          cb([makeVehicleModel({ id: 'veh-99' })]);
+          return mockVehicleSub;
+        }),
+      });
+      const navigate = jest.fn();
+      const { getByText } = render(
+        <CustomerDetailScreen route={makeRoute() as any} navigation={makeNavigation({ navigate }) as any} />
+      );
+      await act(async () => {});
+      fireEvent.press(getByText('Toyota Vios (White) — ABC 1234'));
+      expect(navigate).toHaveBeenCalledWith('VehicleDetail', { vehicleId: 'veh-99' });
+    });
+
+    it('navigates to VehicleForm with customerId on Add Vehicle press', async () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn().mockResolvedValue(makeCustomerModel()),
+      });
+      const navigate = jest.fn();
+      const { getByTestId } = render(
+        <CustomerDetailScreen route={makeRoute('cust-1') as any} navigation={makeNavigation({ navigate }) as any} />
+      );
+      await act(async () => {});
+      fireEvent.press(getByTestId('btn-Add Vehicle'));
+      expect(navigate).toHaveBeenCalledWith('VehicleForm', { customerId: 'cust-1' });
+    });
+  });
+
+  describe('transaction history section', () => {
+    it('shows EmptyState when no transactions', async () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn().mockResolvedValue(makeCustomerModel()),
+      });
+      mockObserveTxns.mockReturnValue({
+        subscribe: jest.fn((cb: (t: unknown[]) => void) => { cb([]); return mockTxSub; }),
+      });
+      const { getByTestId } = render(
+        <CustomerDetailScreen route={makeRoute() as any} navigation={makeNavigation() as any} />
+      );
+      await act(async () => {});
+      expect(getByTestId('empty-No Transactions')).toBeTruthy();
+    });
+
+    it('renders FINALIZED transaction row with total and status badge', async () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn().mockResolvedValue(makeCustomerModel()),
+      });
+      mockObserveTxns.mockReturnValue({
+        subscribe: jest.fn((cb: (t: unknown[]) => void) => {
+          cb([makeTxnModel({ status: 'FINALIZED', totalAmount: 1500 })]);
+          return mockTxSub;
+        }),
+      });
+      const { getByTestId } = render(
+        <CustomerDetailScreen route={makeRoute() as any} navigation={makeNavigation() as any} />
+      );
+      await act(async () => {});
+      expect(getByTestId('badge-Finalized')).toBeTruthy();
+    });
+
+    it('filters out IN_PROGRESS transactions', async () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn().mockResolvedValue(makeCustomerModel()),
+      });
+      mockObserveTxns.mockReturnValue({
+        subscribe: jest.fn((cb: (t: unknown[]) => void) => {
+          cb([makeTxnModel({ status: 'IN_PROGRESS' })]);
+          return mockTxSub;
+        }),
+      });
+      const { getByTestId, queryByTestId } = render(
+        <CustomerDetailScreen route={makeRoute() as any} navigation={makeNavigation() as any} />
+      );
+      await act(async () => {});
+      expect(queryByTestId('badge-In Progress')).toBeNull();
+      expect(getByTestId('empty-No Transactions')).toBeTruthy();
+    });
+
+    it('navigates to TransactionHistoryDetail on transaction row press', async () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn().mockResolvedValue(makeCustomerModel()),
+      });
+      mockObserveTxns.mockReturnValue({
+        subscribe: jest.fn((cb: (t: unknown[]) => void) => {
+          cb([makeTxnModel({ id: 'txn-xyz', status: 'FINALIZED' })]);
+          return mockTxSub;
+        }),
+      });
+      const navigate = jest.fn();
+      const { getByTestId } = render(
+        <CustomerDetailScreen route={makeRoute() as any} navigation={makeNavigation({ navigate }) as any} />
+      );
+      await act(async () => {});
+      fireEvent.press(getByTestId('txn-row-txn-xyz'));
+      expect(navigate).toHaveBeenCalledWith('Transactions', {
+        screen: 'TransactionHistoryDetail',
+        params: { transactionId: 'txn-xyz' },
+      });
+    });
+  });
+
+  describe('subscriptions', () => {
+    it('unsubscribes from observables on unmount', async () => {
+      (mockDatabase.get as jest.Mock).mockReturnValue({
+        find: jest.fn().mockResolvedValue(makeCustomerModel()),
+      });
+      const { unmount } = render(
+        <CustomerDetailScreen route={makeRoute() as any} navigation={makeNavigation() as any} />
+      );
+      await act(async () => {});
+      unmount();
+      expect(mockVehicleSub.unsubscribe).toHaveBeenCalled();
+      expect(mockTxSub.unsubscribe).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `CustomerDetailScreen` as a read-only detail view for a customer
- Shows customer info (name, type badge, phone, email) with an Edit button
- Vehicles section lists all vehicles via `observeVehiclesForCustomer` with tap-to-navigate and an Add Vehicle button
- Transaction history section shows FINALIZED/VOIDED/RETURNED transactions with date, total, and status badge; tapping navigates to `TransactionHistoryDetail`
- Both lists show `EmptyState` when empty; data refreshes on focus via `useFocusEffect`
- 15 unit tests covering all sections, navigation flows, empty states, filtering, and subscription cleanup

## Test plan

- [ ] Navigate to Admin → Customer List → tap a named customer
- [ ] Verify customer name, type badge (Named/Walk-in), phone, and email are displayed
- [ ] Tap **Edit** — should navigate to `CustomerForm` pre-filled with the customer's data
- [ ] Verify **Vehicles** section lists all linked vehicles as `{make} {model} ({color}) — {plateNumber}`
- [ ] Tap a vehicle row — should navigate to `VehicleDetail`
- [ ] Tap **Add Vehicle** — should navigate to `VehicleForm` with `customerId` (no `vehicleId`)
- [ ] Verify **Transaction History** shows only FINALIZED / VOIDED / RETURNED transactions
- [ ] Verify each transaction row shows date, formatted total (₱), and status badge
- [ ] Tap a transaction row — should navigate to `TransactionHistoryDetail`
- [ ] Verify both sections show `EmptyState` when a customer has no vehicles / no transactions
- [ ] Navigate away and back — data should refresh on focus

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)